### PR TITLE
fix: Reset state via browser to preserve auth cookie

### DIFF
--- a/ui-tests-protractor/e2e/app.po.ts
+++ b/ui-tests-protractor/e2e/app.po.ts
@@ -231,6 +231,16 @@ export class AppPage {
     return this.goToUrl(AppPage.baseurl);
   }
 
+  async resetState(): P<boolean> {
+    const link = await this.getApiUrl();
+    log.info('resetting application state');
+
+    browser.waitForAngularEnabled(false);
+    this.goToUrl(`${link}/test-support/reset-db`);
+    browser.waitForAngularEnabled(true);
+    return true;
+  }
+
 
   /**
    * Hook into browser and fetch config.json

--- a/ui-tests-protractor/e2e/common/common.steps.ts
+++ b/ui-tests-protractor/e2e/common/common.steps.ts
@@ -32,7 +32,7 @@ class CommonSteps {
     // user must be logged in (we need his token)
     const result = await this.world.app.login(this.world.user);
     // reset state or fail this step
-    return this.world.resetState();
+    return this.world.app.resetState();
   }
 
   @given(/^application state "([^"]*)"$/)


### PR DESCRIPTION
This is a bit naive, but seems to work fine.