### PR TITLE
chore: Rm WebDriver version lock

### DIFF
--- a/ui-tests-protractor/package.json
+++ b/ui-tests-protractor/package.json
@@ -8,7 +8,7 @@
     "test:xvfb": "docker run --rm -v `pwd`:/syndesis-ui:z -w /syndesis-ui -u `id -u` docker.io/syndesis/karma-xvfb ./karma-xvfb.sh",
     "pree2e": "webdriver-manager update --ignore_ssl",
     "e2e": "better-npm-run e2e:local",
-    "pree2e:syndesis-qe": "webdriver-manager update --versions.chrome 2.30",
+    "pree2e:syndesis-qe": "webdriver-manager update",
     "e2e:syndesis-qe": "better-npm-run e2e:syndesis-qe",
     "e2e:xvfb": "docker run -e SYNDESIS_UI_URL=$SYNDESIS_UI_URL --rm -v `pwd`:/syndesis-ui:z -w /syndesis-ui -u `id -u` docker.io/syndesis/karma-xvfb ./e2e-xvfb.sh"
   },


### PR DESCRIPTION
Since the update of karma-xvfb image, this should be fine with latest WebDriver version.