### PR TITLE
fix: Fix Datamapper field click too close to top

### DIFF
--- a/ui-tests-protractor/e2e/integrations/edit/datamapper.po.ts
+++ b/ui-tests-protractor/e2e/integrations/edit/datamapper.po.ts
@@ -100,7 +100,7 @@ export class DataMapperComponent implements SyndesisComponent {
       // click on it to expand or select
       // find correct field from list
       log.info(`Clicking on field ${p}`);
-      await nextField.click();
+      await nextField.$('label').click();
       // find all subfields for next iteration
       fields = await nextField.$$('document-field-detail');
     }


### PR DESCRIPTION
Top entries are too close to top bars, which is un-clickable. 