### PR TITLE
Stability improvements

### DIFF
--- a/ui-tests-protractor/e2e/common/common.steps.ts
+++ b/ui-tests-protractor/e2e/common/common.steps.ts
@@ -198,7 +198,7 @@ class CommonSteps {
   public async selectFromDropDown(option: string, selectId: string): P<any> {
     const selectSelector = `select[id="${selectId}"]`;
     const selectElement = await this.world.app.getElementByCssSelector(selectSelector);
-    await browser.wait(ExpectedConditions.visibilityOf(selectElement), 6000, `Input ${selectId} not loaded in time`);
+    await browser.wait(ExpectedConditions.visibilityOf(selectElement), 30 * 1000, `Input ${selectId} not loaded in time`);
     return this.world.app.selectOption(selectElement, option);
   }
 

--- a/ui-tests-protractor/e2e/conf/protractor.base.conf.js
+++ b/ui-tests-protractor/e2e/conf/protractor.base.conf.js
@@ -28,13 +28,6 @@ exports.config = {
   baseUrl: 'http://localhost:4200/',
   framework: 'custom',
   frameworkPath: require.resolve('protractor-cucumber-framework'),
-  plugins: [{
-    package: 'protractor-console-plugin',
-    failOnWarning: false,
-    failOnError: false,
-    logWarnings: true,
-    exclude: {}
-  }],
   cucumberOpts: {
     require: [
       testPath + '/env.ts',

--- a/ui-tests-protractor/e2e/integrations/integrations-sf-db.feature
+++ b/ui-tests-protractor/e2e/integrations/integrations-sf-db.feature
@@ -4,8 +4,10 @@ Feature: Test to verify correct function of connections kebab menu
 https://app.zenhub.com/workspace/o/syndesisio/syndesis-qe/issues/102
 https://drive.google.com/file/d/0B_udTBpEdqO8WUxzTWVKX1NsME0/view
 
-    Scenario: Create salesforce connection
+    Scenario: Clean application state
         Given clean application state
+
+    Scenario: Create salesforce connection
         # create salesforce connection
         When "Camilla" navigates to the "Connections" page
         And clicks on the "Create Connection" button

--- a/ui-tests-protractor/package.json
+++ b/ui-tests-protractor/package.json
@@ -59,7 +59,6 @@
     "fs-extra": "^2.0.0",
     "ncp": "^2.0.0",
     "protractor": "5.1.1",
-    "protractor-console-plugin": "^0.1.1",
     "protractor-cucumber-framework": "^0.6.0",
     "ts-node": "2.1.0",
     "tslint": "^4.5.1",

--- a/ui-tests-protractor/yarn.lock
+++ b/ui-tests-protractor/yarn.lock
@@ -3726,12 +3726,6 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-protractor-console-plugin@^0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/protractor-console-plugin/-/protractor-console-plugin-0.1.1.tgz#749da95b0695dede43b50fef3faf9f0b62a47c96"
-  dependencies:
-    q "^1.4.1"
-
 protractor-cucumber-framework@^0.6.0:
   version "0.6.0"
   resolved "https://registry.yarnpkg.com/protractor-cucumber-framework/-/protractor-cucumber-framework-0.6.0.tgz#d1259c7836f5ead010df341c0f6de48b640b7c47"


### PR DESCRIPTION
Overall stability improvements

- remove protractor-console-plugin as it's not doing desired reports
- increase timeout for dynamic dropdowns to 30s
- move clean in SF DB scenario for constistency