### PR TITLE
fix: Match the exact text in dropdown select

### DIFF
--- a/ui-tests-protractor/e2e/app.po.ts
+++ b/ui-tests-protractor/e2e/app.po.ts
@@ -217,9 +217,12 @@ export class AppPage {
   }
 
   async selectOption(select: ElementFinder, option: string): P<any> {
-    const optionSelect = await select.element(by.cssContainingText('option', option));
-
-    return optionSelect.click();
+    return select.all(by.tagName('option')).filter((elem) =>  {
+      return elem.getText().then( (text) => {
+        //match exact String
+        return text === option;
+      });
+    }).click();
   }
 
   async link(title: String): P<NavLink> {


### PR DESCRIPTION
Avoid situation that other variant of e.g. `Contact ...` is selected. Also it seems to be more stable for TwitterScreenName.