### PR TITLE
chore: Add BDD example to rest-tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,9 +32,9 @@
 		<logback.classic.version>1.2.3</logback.classic.version>
 		<force.rest.api.version>0.0.37</force.rest.api.version>
 		<openshift.version>5.6.0.Final</openshift.version>
-		<selenide.version>4.8.0</selenide.version>
+		<selenide.version>4.8</selenide.version>
 		<guava.version>22.0</guava.version>
-		<cucumber.version>1.2.5</cucumber.version>
+		<cucumber.version>2.1.0</cucumber.version>
 		<openshift.client.version>2.4.1</openshift.client.version>
 		<assertj.version>3.8.0</assertj.version>
 		<rxjava.version>1.3.0</rxjava.version>
@@ -225,13 +225,13 @@
 				<version>${guava.version}</version>
 			</dependency>
 			<dependency>
-				<groupId>info.cukes</groupId>
+				<groupId>io.cucumber</groupId>
 				<artifactId>cucumber-java</artifactId>
 				<version>${cucumber.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>info.cukes</groupId>
+				<groupId>io.cucumber</groupId>
 				<artifactId>cucumber-junit</artifactId>
 				<version>${cucumber.version}</version>
 				<scope>test</scope>
@@ -296,7 +296,6 @@
 			</activation>
 			<modules>
 				<module>ui-tests</module>
-				<module>utilities</module>
 			</modules>
 		</profile>
 	</profiles>

--- a/rest-tests/pom.xml
+++ b/rest-tests/pom.xml
@@ -12,26 +12,6 @@
 	<artifactId>rest-tests</artifactId>
 	<name>syndesis rest tests</name>
 
-	<properties>
-		<rest.assured.version>3.0.3</rest.assured.version>
-		<lombok.version>1.16.6</lombok.version>
-		<org.slfj.version>1.7.6</org.slfj.version>
-		<hibernate.version>4.1.0.Final</hibernate.version>
-		<junit.version>4.12</junit.version>
-		<hamcrest.version>1.3</hamcrest.version>
-		<org.json.version>20160810</org.json.version>
-		<commons.io.version>2.5</commons.io.version>
-		<resteasy.version>3.1.4.Final</resteasy.version>
-		<jackson.version>2.8.6</jackson.version>
-		<twitter4j.version>[4.0,)</twitter4j.version>
-		<log4j.version>2.9.0</log4j.version>
-		<force.rest.api.version>0.0.37</force.rest.api.version>
-		<openshift.version>5.6.0.Final</openshift.version>
-		<selenide.version>4.5.1</selenide.version>
-		<guava.version>21.0</guava.version>
-		<cucumber.version>1.2.2</cucumber.version>
-	</properties>
-
 	<dependencies>
 
 		<dependency>
@@ -131,26 +111,17 @@
 		</dependency>
 
 		<dependency>
-			<groupId>com.codeborne</groupId>
-			<artifactId>selenide</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.guava</groupId>
-					<artifactId>guava</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
+
 		<dependency>
-			<groupId>info.cukes</groupId>
+			<groupId>io.cucumber</groupId>
 			<artifactId>cucumber-java</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>info.cukes</groupId>
+			<groupId>io.cucumber</groupId>
 			<artifactId>cucumber-junit</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/rest-tests/src/test/java/io/syndesis/qe/rest/RestTestSuite.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/RestTestSuite.java
@@ -16,9 +16,5 @@ import io.syndesis.qe.templates.SyndesisTemplate;
 public class RestTestSuite {
 
 
-	@BeforeClass
-	public static void prepareEnvironment() {
-		SyndesisTemplate.deploy();
-	}
 
 }

--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/CucumberTestsRunner.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/CucumberTestsRunner.java
@@ -1,0 +1,16 @@
+package io.syndesis.qe.rest.tests;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(
+		features = "classpath:features",
+		format = {"pretty", "html:target/cucumber-report.html", "junit:target/cucumber-junit.html"})
+public class CucumberTestsRunner {
+
+	//we could have some setup here
+
+}

--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/CommonSteps.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/CommonSteps.java
@@ -1,0 +1,34 @@
+package io.syndesis.qe.rest.tests.steps;
+
+import java.util.concurrent.TimeoutException;
+
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
+import io.syndesis.qe.templates.SyndesisTemplate;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class CommonSteps {
+
+	@Given("user cleans default namespace")
+	public void cleanNamespace() {
+		OpenShiftUtils.getInstance().cleanProject();
+	}
+
+	@When("user deploys Syndesis from template")
+	public void deploySyndesis() {
+		SyndesisTemplate.deploy();
+	}
+
+	@Then("user waits for Syndesis to become ready")
+	public void waitForSyndeisis() {
+		try {
+			OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.isAPodReady("component", "syndesis-rest"));
+		} catch (InterruptedException | TimeoutException e) {
+			log.error("Wait for syndesis-rest failed ", e);
+		}
+	}
+}

--- a/rest-tests/src/test/resources/features/common.feature
+++ b/rest-tests/src/test/resources/features/common.feature
@@ -1,0 +1,7 @@
+Feature: Common scenarios
+
+@clean-deploy
+Scenario: Clean & deploy
+	Given user cleans default namespace
+	When user deploys Syndesis from template
+	Then user waits for Syndesis to become ready

--- a/ui-tests/pom.xml
+++ b/ui-tests/pom.xml
@@ -28,12 +28,12 @@
 		</dependency>
 
 		<dependency>
-			<groupId>info.cukes</groupId>
+			<groupId>io.cucumber</groupId>
 			<artifactId>cucumber-java</artifactId>
+			<scope>test</scope>
 		</dependency>
-
 		<dependency>
-			<groupId>info.cukes</groupId>
+			<groupId>io.cucumber</groupId>
 			<artifactId>cucumber-junit</artifactId>
 			<scope>test</scope>
 		</dependency>
@@ -47,7 +47,6 @@
 		<dependency>
 			<groupId>com.codeborne</groupId>
 			<artifactId>selenide</artifactId>
-			<version>4.8</version>
 		</dependency>
 
 	</dependencies>

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -119,16 +119,7 @@
 			<groupId>com.google.guava</groupId>
 			<artifactId>guava</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>info.cukes</groupId>
-			<artifactId>cucumber-java</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>info.cukes</groupId>
-			<artifactId>cucumber-junit</artifactId>
-		</dependency>
-
-
+		
 		<!-- Third party services dependencies -->
 		<dependency>
 			<groupId>org.twitter4j</groupId>

--- a/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
@@ -1,11 +1,14 @@
 package io.syndesis.qe.templates;
 
+import org.apache.commons.codec.binary.Base64;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.TimeoutException;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.api.model.Secret;
@@ -13,7 +16,7 @@ import io.fabric8.kubernetes.api.model.ServiceAccount;
 import io.fabric8.openshift.api.model.Template;
 import io.syndesis.qe.TestConfiguration;
 import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.wait.OpenShiftWaitUtils;
+import io.syndesis.qe.utils.TestUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -42,11 +45,20 @@ public class SyndesisTemplate {
 		OpenShiftUtils.getInstance().cleanProject();
 
 		// get & create restricted SA
-		OpenShiftUtils.getInstance().withDefaultUser(client -> client.serviceAccounts().createOrReplace(getSupportSA()));
-		OpenShiftUtils.getInstance().getServiceAccounts().stream().forEach(sa -> log.info(sa.getMetadata().getName()));
-		// get token from SA `oc secrets get-token`
+		ServiceAccount serviceAccount1 = OpenShiftUtils.getInstance().withDefaultUser(client -> client.serviceAccounts().createOrReplace(getSupportSA()));
+		// get token from SA `oc secrets get-token` && wait until created to prevent 404
+		TestUtils.waitForEvent(Optional::isPresent,
+				() -> OpenShiftUtils.getInstance().getSecrets().stream().filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token")).findFirst(),
+				TimeUnit.MINUTES,
+				2,
+				TimeUnit.SECONDS,
+				5);
+
 		Secret secret = OpenShiftUtils.getInstance().getSecrets().stream().filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token")).findFirst().get();
-		String oauthToken = secret.getData().get("token");
+		// token is Base64 encoded by default
+		String oauthTokenEncoded = secret.getData().get("token");
+		byte[] oauthTokenBytes = Base64.decodeBase64(oauthTokenEncoded);
+		String oauthToken = new String(oauthTokenBytes);
 
 		// get the template
 		Template template = getTemplate();
@@ -60,11 +72,5 @@ public class SyndesisTemplate {
 		// process & create
 		KubernetesList processedTemplate = OpenShiftUtils.getInstance().processTemplate(template, templateParams);
 		OpenShiftUtils.getInstance().createResources(processedTemplate);
-		OpenShiftUtils.getInstance().createRestRoute();
-		try {
-			OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.isAPodReady("component", "syndesis-rest"));
-		} catch (InterruptedException | TimeoutException e) {
-			log.error("Wait for syndesis-rest failed ", e);
-		}
 	}
 }

--- a/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
@@ -69,8 +69,13 @@ public final class OpenShiftUtils {
 					.withMasterUrl(TestConfiguration.openShiftUrl())
 					.withTrustCerts(true)
 					.withRequestTimeout(120_000)
-					.withNamespace(TestConfiguration.openShiftNamespace())
-					.withOauthToken(TestConfiguration.openShiftToken());
+					.withNamespace(TestConfiguration.openShiftNamespace());
+
+			if (!TestConfiguration.openShiftToken().isEmpty()) {
+				//if token is provided, lets use it
+				//otherwise f8 client should be able to leverage ~/.kube/config or mounted secrets
+				openShiftConfigBuilder.withOauthToken(TestConfiguration.openShiftToken());
+			}
 
 			client = new DefaultOpenShiftClient(openShiftConfigBuilder.build());
 		}


### PR DESCRIPTION
This PR adds simple BDD test that for the given namespace tries to clean&deploy Syndesis.

Note that I've changed Cucumber dependencies to latest version. There was org-id change hence the bigger change in poms.

With proper test.properties PoC is runnable like:
`mvn clean test -P rest -Dtest=CucumberTestsRunner -Dcucumber.options="--tags @clean-deploy"`