### PR TITLE
Clean state via backend & verification in SF to DB

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -125,7 +125,7 @@ public class CommonSteps {
 		allLinks.find(Condition.exactText(title)).shouldBe(visible).click();
 	}
 
-	@Given("^clean application state$")
+	//@Given("^clean application state$")
 	public void resetState() {
 		Long result = (Long) ((JavascriptExecutor) WebDriverRunner.getWebDriver())
 				.executeAsyncScript("var callback = arguments[arguments.length - 1]; " +

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -125,15 +125,6 @@ public class CommonSteps {
 		allLinks.find(Condition.exactText(title)).shouldBe(visible).click();
 	}
 
-	//@Given("^clean application state$")
-	public void resetState() {
-		Long result = (Long) ((JavascriptExecutor) WebDriverRunner.getWebDriver())
-				.executeAsyncScript("var callback = arguments[arguments.length - 1]; " +
-						"$.get('/api/v1/test-support/reset-db', function(data, textStatus, jqXHR) { callback(jqXHR.status); })");
-
-		Assertions.assertThat(String.valueOf(result)).isEqualTo("204");
-	}
-
 	@Then("^\"(\\w+)\" is presented with the Syndesis home page$")
 	public void checkHomePageVisibility(String username) {
 		syndesisRootPage.getRootElement().shouldBe(visible);

--- a/ui-tests/src/test/resources/features/integrations/salesforce-to-database.feature
+++ b/ui-tests/src/test/resources/features/integrations/salesforce-to-database.feature
@@ -3,8 +3,8 @@ Feature: Test to verify correct function of connections kebab menu
 
 
   Background: Clean application state
-    Given "Camilla" logs into the Syndesis
     Given clean application state
+    Given "Camilla" logs into the Syndesis
     Given created connections
       | Salesforce | QE Salesforce | QE Salesforce | SyndesisQE salesforce test |
 
@@ -74,3 +74,6 @@ Feature: Test to verify correct function of connections kebab menu
     And she clicks on the "Done" button
       # wait for integration to get in active state
     Then she wait until integration "Salesforce to PostresDB E2E" get into "Active" state
+    And create SF lead with first name: "John", last name: "Doe", email: "jdoe@acme.com" and company: "ACME"
+    And validate SF to DB created new lead with first name: "John", last name: "Doe", email: "jdoe@acme.com"
+    And clean after SF to DB, removes user with first name: "John" and last name: "Doe"

--- a/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
@@ -13,6 +13,7 @@ import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
+import io.syndesis.qe.endpoints.TestSupport;
 import io.syndesis.qe.templates.AmqTemplate;
 import io.syndesis.qe.templates.SyndesisTemplate;
 import io.syndesis.qe.utils.DbUtils;
@@ -89,6 +90,14 @@ public class CommonSteps {
 		dbUtils.deleteRecordsInTable("TODO");
 		SampleDbConnectionManager.getInstance().closeConnection();
 	}
+
+	@Given("^clean application state")
+	public void resetState() {
+		int responseCode = TestSupport.getInstance().resetDbWithResponse();
+		Assertions.assertThat(responseCode).isEqualTo(204);
+	}
+
+
 
 
 

--- a/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
@@ -96,9 +96,4 @@ public class CommonSteps {
 		int responseCode = TestSupport.getInstance().resetDbWithResponse();
 		Assertions.assertThat(responseCode).isEqualTo(204);
 	}
-
-
-
-
-
 }

--- a/utilities/src/main/java/io/syndesis/qe/endpoints/TestSupport.java
+++ b/utilities/src/main/java/io/syndesis/qe/endpoints/TestSupport.java
@@ -16,7 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class TestSupport {
 
-	private static final String ENDPOINT_NAME = "test-support";
+	private static final String ENDPOINT_NAME = "/test-support";
 	private static final String apiPath = TestConfiguration.syndesisRestApiPath();
 	private static Client client;
 	private static TestSupport instance = null;
@@ -33,11 +33,18 @@ public final class TestSupport {
 	}
 
 	/**
-	 * Resets syndesis database.
-	 *
-	 * @param token
+	 * Resets Syndesis database.
 	 */
-	public static void resetDB() {
+	public void resetDB() {
+		resetDbWithResponse();
+	}
+
+	/**
+	 * Resets Syndesis database.
+	 *
+	 * @return HTTP response code
+	 */
+	public int resetDbWithResponse() {
 		log.info("Resetting syndesis DB.");
 
 		final Invocation.Builder invocation = client
@@ -45,10 +52,12 @@ public final class TestSupport {
 				.request(MediaType.APPLICATION_JSON)
 				.header("X-Forwarded-User", "pista")
 				.header("X-Forwarded-Access-Token", "kral");
-		invocation.get();
+		int responseCode = invocation.get().getStatus();
+		log.debug("Reset endpoint reponse: {}", responseCode);
+		return responseCode;
 	}
 
-	public static String getEndpointUrl() {
+	public String getEndpointUrl() {
 		return String.format("%s%s%s%s", RestUtils.getRestUrl(), apiPath, ENDPOINT_NAME, "/reset-db");
 	}
 }


### PR DESCRIPTION
A small disclaimer: I've deliberately kept `resetState()` via browser as a reference.
