### PR TITLE
[ui][new] adding test for Slack consumer

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/BasicFilter.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/BasicFilter.java
@@ -26,17 +26,17 @@ public class BasicFilter extends AbstractStep {
     }
 
     private static final class Input {
-        public static final By PATH = By.cssSelector("input[ng-reflect-name='path']");
-        public static final By VALUE = By.cssSelector("input[ng-reflect-name='value']");
+        public static final By PATH = By.cssSelector("input[formcontrolname='path']");
+        public static final By VALUE = By.cssSelector("input[formcontrolname='value']");
     }
 
     private static final class Select {
         public static final By PREDICATE = By.id("basicFilterPredicateSelect");
-        public static final By OP = By.cssSelector("select[ng-reflect-name='op']");
+        public static final By OP = By.cssSelector("select[formcontrolname='op']");
     }
 
     private static final class Link {
-        public static final By ADD_RULE = By.cssSelector("a.add-rule");
+        public static final By ADD_RULE = By.cssSelector(".add-rule");
     }
 
     private static final class DataList {

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/other/SlackSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/other/SlackSteps.java
@@ -15,8 +15,14 @@ public class SlackSteps {
     private SlackConnector slack;
 
     @When("^.*checks? that last slack message equals \"([^\"]*)\" on channel \"([^\"]*)\"$")
-    public void sendMessage(String message, String channel) throws InterruptedException, SlackApiException, IOException {
+    public void checkMessage(String message, String channel) throws SlackApiException, IOException {
         TestUtils.sleepForJenkinsDelayIfHigher(2);
         slack.checkLastMessageFromChannel(message, channel);
+    }
+
+    @When("^.*send? message \"([^\"]*)\" on channel \"([^\"]*)\"$")
+    public void sendMessage(String message, String channel) throws InterruptedException, SlackApiException, IOException {
+        TestUtils.sleepForJenkinsDelayIfHigher(2);
+        slack.sendMessage(message, channel);
     }
 }

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/DbValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/DbValidationSteps.java
@@ -188,6 +188,11 @@ public class DbValidationSteps {
         assertThat(dbUtils.getCountOfInvokedQuery(query)).isGreaterThanOrEqualTo(1);
     }
 
+    @Then("^.*checks? that query \"([^\"]*)\" has no output$")
+    public void checkValuesNotExistInTable(String query) {
+        assertThat(dbUtils.getCountOfInvokedQuery(query)).isEqualTo(0);
+    }
+
     @And("^.*invokes? database query \"([^\"]*)\"")
     public void invokeQuery(String query) {
         assertThat(dbUtils.executeSQLGetUpdateNumber(query)).isGreaterThanOrEqualTo(0);

--- a/utilities/src/main/java/io/syndesis/qe/utils/SlackConnector.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/SlackConnector.java
@@ -35,10 +35,10 @@ public class SlackConnector {
      * is API Token for slack workspace custom integration called "Bots".
      */
     public SlackConnector() {
-        Optional<Account> optional = AccountsDirectory.getInstance().getAccount("QE Slack");
+        Optional<Account> accountInfo = AccountsDirectory.getInstance().getAccount("QE Slack consumer");
 
-        if (optional.isPresent()) {
-            SlackConnector.token = optional.get().getProperties().get("Token");
+        if (accountInfo.isPresent()) {
+            SlackConnector.token = accountInfo.get().getProperties().get("token");
         } else {
             throw new InvalidParameterException("Credentials for QE Slack connector not found!");
         }


### PR DESCRIPTION
- The test for the Slack consumer was added
- The CSS selectors in the BasicFilter were updated
- SlackConnector was updated according to updated [credentials](https://gitlab.cee.redhat.com/jboss-fuse-qe/ci-ops-fuse/commit/2fea1870138ebdbde9da859f3ac36fb1c851ac94?merge_request_iid=146). 

//test: @slack-to-db