### PR TITLE
[rest][fix] add missing flow id + name to filter

### DIFF
--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/integrations/IntegrationHandler.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/integrations/IntegrationHandler.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.ws.rs.BadRequestException;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 import cucumber.api.java.en.Then;
@@ -55,6 +56,7 @@ public class IntegrationHandler {
                 .addFlow(
                     new Flow.Builder()
                         .steps(steps.getSteps())
+                        .id(UUID.randomUUID().toString())
                         .description(integrationName + "Flow")
                         .build()
                 )

--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/integrations/IntermediateSteps.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/integrations/IntermediateSteps.java
@@ -52,6 +52,7 @@ public class IntermediateSteps {
                         "rules", new FilterRulesBuilder().addPath(path).addValue(value).addOps(operation).build()
                 ))
                 .id(UUID.randomUUID().toString())
+                .name("Rule Filter " + path)
                 .build();
         steps.getStepDefinitions().add(new StepDefinition(basicFilter));
     }


### PR DESCRIPTION
Fixing missing flow id when creating Integration.

Doesn't affect tests really, only issue was viewing the Integration created by REST tests.

Also noticed that Rule Filters don't have name specified, fixing that.