### PR TITLE
Fix selection in Data Mapper

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -153,9 +153,9 @@ public class DataMapper extends SyndesisPageObject {
 
                 new Actions(WebDriverRunner.getWebDriver())
                         .moveToElement(el)
-                        .keyDown(Keys.LEFT_CONTROL)
+                        .keyDown(Keys.META)
                         .click()
-                        .keyUp(Keys.LEFT_CONTROL)
+                        .keyUp(Keys.META)
                         .perform();
 
             }


### PR DESCRIPTION
This was broken due to https://bugzilla.mozilla.org/show_bug.cgi?id=1421323
Changing CONTROL to META seems to work in both ff and chrome on linux.