### PR TITLE
[ui][fix] remove outdated step in concur feature

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/concur.feature
+++ b/ui-tests/src/test/resources/features/integrations/concur.feature
@@ -137,7 +137,6 @@ Feature: Concur Connector
     When click on the "Save" button
     And set integration name "Integration_with_concur"
     And publish integration
-    Then check visibility of "Integration_with_concur" integration details
 
     When navigate to the "Integrations" page
     Then Integration "Integration_with_concur" is present in integrations list


### PR DESCRIPTION
//skip-ci

Skipping tests as they do not work for now - our concur credentials do not have correct permissions to access SAP concur instance endpoints, resulting in 403 error.