### PR TITLE
[ui][fix] change to log connector in kudu tests due to removal of log step

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/kudu.feature
+++ b/ui-tests/src/test/resources/features/integrations/kudu.feature
@@ -96,14 +96,9 @@ Feature: Kudu connector
     Then check that position of connection to fill is "Finish"
 
     When select the "Log" connection
-    And select "Simple Logger" integration action
-
     And fill in values
-      | log level      | ERROR |
-      | Log Body       | true  |
-      | Log message Id | true  |
-      | Log Headers    | true  |
-      | Log everything | true  |
+      | Message Context | true |
+      | Message Body    | true |
 
     Then click on the "Done" button
 


### PR DESCRIPTION
//test: `@integrations-kudu-scan`