### PR TITLE
[ui][fix] kudu tests - do not fail with empty pod logs 16x

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/templates/KuduRestAPITemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/KuduRestAPITemplate.java
@@ -96,6 +96,7 @@ public class KuduRestAPITemplate {
             try {
                 OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.areExactlyNPodsReady(LABEL_NAME, APP_NAME, 1), 15 * 60 * 1000L);
                 log.info("Checking pod logs if the app is ready");
+                OpenShiftWaitUtils.waitFor(() -> !OpenShiftUtils.arePodLogsEmpty(APP_NAME), 5 * 60 * 1000L);
                 OpenShiftWaitUtils.waitFor(() -> OpenShiftUtils.getPodLogs(APP_NAME).contains("Started App in"), 5 * 60 * 1000L);
             } catch (InterruptedException | TimeoutException e) {
                 fail("Wait for " + APP_NAME + " deployment failed ", e);

--- a/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
@@ -131,6 +131,14 @@ public final class OpenShiftUtils {
         return null;
     }
 
+    public static boolean arePodLogsEmpty(String podPartialName) {
+        // pod has to be in running state because pod in ContainerCreating state causes exception
+        OpenShiftWaitUtils.waitUntilPodIsRunning(podPartialName);
+
+        Optional<Pod> integrationPod = getPodByPartialName(podPartialName);
+        return integrationPod.map(pod -> OpenShiftUtils.getInstance().getPodLog(pod).isEmpty()).orElse(true);
+    }
+
     /**
      * Invoke openshift's API. Only part behind master url is necessary and the path must start with slash.
      * @param method HTTP method to use


### PR DESCRIPTION
//test: `@integrations-kudu`