### PR TITLE
fix @integration-check-starting-status-on-detail-page

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/IntegrationSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/IntegrationSteps.java
@@ -6,6 +6,7 @@ import static org.assertj.core.api.Assertions.fail;
 import static com.codeborne.selenide.Condition.visible;
 
 import cucumber.api.PendingException;
+
 import org.assertj.core.api.Condition;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -231,6 +232,27 @@ public class IntegrationSteps {
                         fail("Integration status can't be checked on <" + checkedPage + "> page. Only valid options are [Integrations, Integration detail, Home]");
                 }
                 break;
+            } else {
+
+                boolean published = false;
+                switch (checkedPage) {
+                    case "Integrations":
+                        if (integrations.getIntegrationItemStatus(integrations.getIntegration(integrationName)).trim().equals("Running")) {
+                            published = true;
+                        }
+                        break;
+                    case "Integration detail":
+                    if (detailPage.getPublishedVersion().getText().trim().equals("Published version 1")) {
+                            published = true;
+                        }
+                    break;
+                    default:
+                        break;
+                }
+
+                if(published) {
+                    break;
+                }
             }
 
             String status = "";

--- a/ui-tests/src/test/resources/features/integrations/integration-status.feature
+++ b/ui-tests/src/test/resources/features/integrations/integration-status.feature
@@ -3,7 +3,7 @@
 @ui
 @database
 @integrations-check-starting-status
-Feature: Integration - DB to DB
+Feature: Integration status
 
   Background: Clean application state
     Given clean application state


### PR DESCRIPTION
//test: `@integrations-check-starting-status`