### PR TITLE
fix @create-delete-api-connector (wait for modalDialog to be closed) 1.6.x

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/ModalDialogPage.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/ModalDialogPage.java
@@ -10,7 +10,7 @@ import com.codeborne.selenide.SelenideElement;
 public class ModalDialogPage extends SyndesisPageObject {
 
     private static final class Element {
-        public static final By ROOT = By.className("modal-dialog");
+        public static final By ROOT = By.className("modal-content");
 
         public static final By HEADER = By.className("modal-header");
         public static final By TITLE = By.className("modal-title");

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -384,15 +384,28 @@ public class CommonSteps {
 
     @When("cancel modal dialog window$")
     public void cancelModalDialogWindow() {
-        if (modalDialogPage.validate()) {
-            modalDialogPage.getButton("Cancel").shouldBe(visible).click();
-        }
 
-        try {
-            OpenShiftWaitUtils.waitFor(() -> !modalDialogPage.validate(), 15 * 1000L);
-        } catch (InterruptedException | TimeoutException e) {
+        boolean modalDialogClosed = false;
+
+        //wait 20 seconds max
+        for(int i=0;i<20;i++) {
+            if (modalDialogPage.validate()) {
+                modalDialogPage.getButton("Cancel").shouldBe(visible).click();
+            }
+
+            try {
+                OpenShiftWaitUtils.waitFor(() -> !modalDialogPage.validate(), 1000L);
+                modalDialogClosed = true;
+                break;
+            } catch (InterruptedException | TimeoutException e) {
+                // intentionally left blank
+            }
+        }
+        //fail if modalDialog still open
+        if(!modalDialogClosed) {
             fail("Modal dialog is still visible after clicking on cancel");
         }
+
     }
 
     @When(".*clicks? on the \"([^\"]*)\" link.*$")


### PR DESCRIPTION
//test: `@create-delete-api-connector`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
