### PR TITLE
Add cucumber formatter for mail report

### DIFF
--- a/rest-tests/src/test/java/io/syndesis/qe/CucumberTestsRunner.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/CucumberTestsRunner.java
@@ -8,7 +8,13 @@ import cucumber.api.junit.Cucumber;
 @RunWith(Cucumber.class)
 @CucumberOptions(
     features = "classpath:features", tags = {"not @integrations-lifecycle", "not @integrations-lifecycle-long", "not @manual", "not @wip", "not @ignore"},
-    plugin = {"pretty", "html:target/cucumber/cucumber-html", "junit:target/cucumber/cucumber-junit.xml", "json:target/cucumber/cucumber-report.json"})
+    plugin = {
+            "pretty",
+            "html:target/cucumber/cucumber-html",
+            "junit:target/cucumber/cucumber-junit.xml",
+            "json:target/cucumber/cucumber-report.json",
+            "io.syndesis.qe.cucumber.MailFormatter:target/cucumber/cucumber-mail/"
+    })
 public class CucumberTestsRunner extends TestSuiteParent {
 
     //we could have some setup here

--- a/ui-tests/src/test/java/io/syndesis/qe/CucumberTest.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/CucumberTest.java
@@ -1,8 +1,10 @@
 package io.syndesis.qe;
 
 import com.codeborne.selenide.Configuration;
+
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
+
 import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 
@@ -11,7 +13,13 @@ import org.junit.runner.RunWith;
         features = "classpath:features",
         extraGlue = {"apicurito.tests.steps"},
         tags = {"not @wip", "not @manual", "not @deprecated", "not @disabled", "not @apicuritoTests"},
-        plugin = {"pretty", "html:target/cucumber/cucumber-html", "junit:target/cucumber/cucumber-junit.xml", "json:target/cucumber/cucumber-report.json"}
+        plugin = {
+                "pretty",
+                "html:target/cucumber/cucumber-html",
+                "junit:target/cucumber/cucumber-junit.xml",
+                "json:target/cucumber/cucumber-report.json",
+                "io.syndesis.qe.cucumber.MailFormatter:target/cucumber/cucumber-mail/"
+        }
 )
 public class CucumberTest extends TestSuiteParent {
 
@@ -23,7 +31,6 @@ public class CucumberTest extends TestSuiteParent {
         //We will now use custom web driver
         //Configuration.browser = TestConfiguration.syndesisBrowser();
         Configuration.browser = "io.syndesis.qe.CustomWebDriverProvider";
-        Configuration.browserSize= "1920x1080";
+        Configuration.browserSize = "1920x1080";
     }
-
 }

--- a/utilities/src/main/java/io/syndesis/qe/cucumber/MailFormatter.java
+++ b/utilities/src/main/java/io/syndesis/qe/cucumber/MailFormatter.java
@@ -1,0 +1,183 @@
+package io.syndesis.qe.cucumber;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+
+import cucumber.api.Result;
+import cucumber.api.TestCase;
+import cucumber.api.event.EmbedEvent;
+import cucumber.api.event.EventListener;
+import cucumber.api.event.EventPublisher;
+import cucumber.api.event.TestCaseFinished;
+import cucumber.api.event.TestRunFinished;
+import cucumber.api.event.TestSourceRead;
+import gherkin.AstBuilder;
+import gherkin.Parser;
+import gherkin.ParserException;
+import gherkin.ast.Comment;
+import gherkin.ast.Feature;
+import gherkin.ast.GherkinDocument;
+import io.syndesis.qe.issue.IssueState;
+import io.syndesis.qe.issue.SimpleIssue;
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class MailFormatter implements EventListener {
+
+    private static final Pattern SUSTAINER_PATTERN = Pattern.compile(".*@sustainer: ([a-zA-Z@.]+)");
+
+    private final String path;
+
+    private ObjectMapper mapper = new ObjectMapper();
+
+    private Map<String, String> sustainers = new HashMap<>();
+    private Map<String, Feature> features = new HashMap<>();
+    private Map<String, List<SimpleIssue>> scenarioIssues = new HashMap<>();
+    private Set<String> recipients = new HashSet<>();
+    private List<ScenarioResult> results = new ArrayList<>();
+
+    public MailFormatter(String path) {
+        this.path = path;
+    }
+
+    @Override
+    public void setEventPublisher(EventPublisher publisher) {
+        publisher.registerHandlerFor(TestSourceRead.class, this::onTestSourceRead);
+        publisher.registerHandlerFor(TestCaseFinished.class, this::onTestCaseFinished);
+        publisher.registerHandlerFor(TestRunFinished.class, this::onTestRunFinished);
+        publisher.registerHandlerFor(EmbedEvent.class, this::onEmbed);
+    }
+
+    private void onEmbed(EmbedEvent t) {
+        if ("application/x.issues+json".equals(t.mimeType)) {
+            try {
+                List<SimpleIssue> issues = mapper.readValue(t.data, new TypeReference<List<SimpleIssue>>() {
+                });
+                scenarioIssues.put(t.getTestCase().getScenarioDesignation(), issues);
+            } catch (IOException e) {
+                // ignoring is ok - there simply won't be an issue list in the report
+                log.error("Unable to process embedded json issues", e);
+            }
+        }
+    }
+
+    private void onTestSourceRead(TestSourceRead t) {
+        GherkinDocument doc = parseGherkinSource(t.source);
+        if (doc != null) {
+            features.put(t.uri, doc.getFeature());
+            for (Comment c : doc.getComments()) {
+                Matcher matcher = SUSTAINER_PATTERN.matcher(c.getText());
+                if (matcher.matches()) {
+                    sustainers.put(t.uri, matcher.group(1));
+                }
+            }
+        }
+    }
+
+    private void onTestCaseFinished(TestCaseFinished t) {
+        String uri = t.getTestCase().getUri();
+        results.add(
+                new ScenarioResult(
+                        features.get(uri), t.getTestCase(), t.result.getStatus(),
+                        sustainers.getOrDefault(uri, "NO SUSTAINER"), scenarioIssues.get(t.getTestCase().getScenarioDesignation()))
+        );
+        if (!t.result.getStatus().equals(Result.Type.PASSED) && sustainers.get(uri) != null) {
+            recipients.add(sustainers.get(uri));
+        }
+    }
+
+    private void onTestRunFinished(TestRunFinished t) {
+        new File(path).mkdirs();
+        try (FileWriter out = new FileWriter(new File(path, "report.html"))) {
+            out.write(String.join(
+                    "<br/>\n",
+                    results.stream().map(ScenarioResult::toString).collect(Collectors.toList())
+                    )
+            );
+        } catch (IOException e) {
+            log.error("Error writing mail report file", e);
+        }
+        try (FileWriter out = new FileWriter(new File(path, "mail-recipients"))) {
+            out.write(String.join("\n", recipients) + "\n");
+        } catch (IOException e) {
+            log.error("Error writing mail recipients file", e);
+        }
+    }
+
+    private GherkinDocument parseGherkinSource(String source) {
+        Parser<GherkinDocument> parser = new Parser<>(new AstBuilder());
+        try {
+            return parser.parse(source);
+        } catch (ParserException e) {
+            log.error("Error parsing gherkin source", e);
+        }
+        return null;
+    }
+
+    @Data
+    @RequiredArgsConstructor
+    private static class ScenarioResult {
+        private final Feature feature;
+        private final TestCase testCase;
+        private final Result.Type result;
+        private final String sustainer;
+        private final List<SimpleIssue> issues;
+
+        public String toString() {
+            // TODO: consider using a templating engine for this
+            StringBuilder sb = new StringBuilder();
+            sb
+                    .append(feature.getName())
+                    .append(" | ")
+                    .append(testCase.getName())
+                    .append(" | ");
+
+            if (result.equals(Result.Type.PASSED)) {
+                sb
+                        .append("<font color=\"green\">")
+                        .append(result)
+                        .append("</font>");
+            } else {
+                sb
+                        .append("<font color=\"red\"><b>")
+                        .append(result)
+                        .append("</b></font>");
+            }
+
+            sb
+                    .append(" | ")
+                    .append(sustainer)
+                    .append(" | ");
+
+            if (issues != null) {
+                for (SimpleIssue issue : issues) {
+                    if (issue.getState() == IssueState.OPEN) {
+                        sb
+                                .append("<a href=\"https://github.com/syndesisio/syndesis/issues/")
+                                .append(issue.getIssueNumber())
+                                .append("\">")
+                                .append(issue.getIssueNumber())
+                                .append("</a>&nbsp;");
+                    }
+                }
+            }
+
+            return sb.toString();
+        }
+    }
+}

--- a/utilities/src/main/java/io/syndesis/qe/issue/IssueState.java
+++ b/utilities/src/main/java/io/syndesis/qe/issue/IssueState.java
@@ -1,0 +1,5 @@
+package io.syndesis.qe.issue;
+
+public enum IssueState {
+    OPEN, DONE, CLOSED
+}

--- a/utilities/src/main/java/io/syndesis/qe/issue/SimpleIssue.java
+++ b/utilities/src/main/java/io/syndesis/qe/issue/SimpleIssue.java
@@ -1,0 +1,17 @@
+package io.syndesis.qe.issue;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class SimpleIssue {
+
+    private int issueNumber;
+    private String url;
+    private IssueState state;
+}


### PR DESCRIPTION
This is an initial implementation of showing open issues in emailed test report.

The basic idea is that there's a custom cucumber formatter that generates almost the whole report (except for some headers etc, which will need to be done exernally, since they need to know about the jenkins build info).

There are two main uglies in this:
1. We already check open issues in `IssueHooks.java`, so to prevent hitting github and zenhub twice for each failure, we embed the downloaded issues into the scenario and then retrieve it when creating the report. This does not seem to cause any trouble for the html report, but is not particularly nice. We might decide that requesting the issues twice is preferable
2. The report is currently built by appending to a `StringBuilder`, we might decide we want to use a templating engine to prevent the ugliness

There are also a bunch of todos which I will resolve once we decide this is the way we want to do things. The same goes for updating the jenkins job to use this new report.

@avano wdyt?


//skip-ci
