### PR TITLE
[FUSEQE-4498] fix tests with sql connector mapping collections

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -121,7 +121,12 @@ public class DataMapper extends SyndesisPageObject {
     }
 
     public void openDataMapperCollectionElement() {
-        $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> e.shouldBe(visible).click());
+        $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
+            SelenideElement arrow = e.find("i.arrow.fa.fa-angle-right");
+            if (arrow.exists() && arrow.is(visible)) {
+                arrow.click();
+            }
+        });
     }
 
     public void doCreateMapping(String source, String target) {

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
@@ -49,6 +49,8 @@ public class DataMapperSteps {
      */
     @When("^create data mapper mappings$")
     public void createMapping(DataTable table) {
+        mapper.openDataMapperCollectionElement();
+
         for (List<String> row : table.cells()) {
             if (row.size() > 2) {
                 mapper.doCreateMappingWithSeparator(row.get(0), row.get(1), row.get(2));


### PR DESCRIPTION
I returned the `DataMapper#openDataMapperCollectionElement` back into `create data mapper mappings` step so that any collections we can find on the data mapping view are opened automatically when we try to create the mapping.

It was previously like that before and was removed for the unknown reason, so I put it back to fix the UI tests with SQL connector collections problems.

Here it also checks that collection is not yet open by looking only for `.fa-angle-right` arrow and clicking it. Opened collections have `.fa-angle-down` arrow.