### PR TITLE
[UI] only automatically open unnamed collections on data mapper

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -122,11 +122,31 @@ public class DataMapper extends SyndesisPageObject {
         doCreateMapping(source, target);
     }
 
+    /**
+     * This method opens all collection mappings we can find on a data mapper
+     */
     public void openDataMapperCollectionElement() {
         $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
             SelenideElement arrow = e.find("i.arrow.fa.fa-angle-right");
             if (arrow.exists() && arrow.is(visible)) {
                 arrow.click();
+            }
+        });
+    }
+
+    /**
+     * This method opens only unnamed collection mappings we can find on a data mapper
+     */
+    public void openDataMapperUnnamedCollectionElement() {
+        $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
+            // if there is label on the collection, which is empty
+            // or if label does not exist, collection is unnamed
+            SelenideElement label = e.find("label");
+            if (!label.exists() || label.text().isEmpty()) {
+                SelenideElement arrow = e.find("i.arrow.fa.fa-angle-right");
+                if (arrow.exists() && arrow.is(visible)) {
+                    arrow.click();
+                }
             }
         });
     }

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -58,6 +58,7 @@ public class DataMapper extends SyndesisPageObject {
         public static final By MAPPER_COLLECTION_ICON = By.className("parentField");
         public static final By ADD_MAPPING_ICON = By.className("fa-plus");
         public static final By ATLASMAP_IFRAME = By.cssSelector("iframe[name=\"atlasmap-frame\"]");
+        public static final By ARROW_POINTING_RIGHT = By.cssSelector("i.arrow.fa.fa-angle-right");
     }
 
     @Override
@@ -127,7 +128,7 @@ public class DataMapper extends SyndesisPageObject {
      */
     public void openDataMapperCollectionElement() {
         $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
-            SelenideElement arrow = e.find("i.arrow.fa.fa-angle-right");
+            SelenideElement arrow = e.find(Element.ARROW_POINTING_RIGHT);
             if (arrow.exists() && arrow.is(visible)) {
                 arrow.click();
             }
@@ -143,7 +144,7 @@ public class DataMapper extends SyndesisPageObject {
             // or if label does not exist, collection is unnamed
             SelenideElement label = e.find("label");
             if (!label.exists() || label.text().isEmpty()) {
-                SelenideElement arrow = e.find("i.arrow.fa.fa-angle-right");
+                SelenideElement arrow = e.find(Element.ARROW_POINTING_RIGHT);
                 if (arrow.exists() && arrow.is(visible)) {
                     arrow.click();
                 }

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
@@ -50,7 +50,11 @@ public class DataMapperSteps {
     @When("^create data mapper mappings$")
     public void createMapping(DataTable table) {
         mapper.switchToDatamapperIframe();
-        mapper.openDataMapperCollectionElement();
+
+        // only automatically open unnamed collections for data mapping
+        // if we want to open named collections, then use specific step for that
+        mapper.openDataMapperUnnamedCollectionElement();
+
         for (List<String> row : table.cells()) {
             if (row.size() > 2) {
                 mapper.doCreateMappingWithSeparator(row.get(0), row.get(1), row.get(2));
@@ -66,6 +70,11 @@ public class DataMapperSteps {
         mapper.switchToDatamapperIframe();
         mapper.openDataMapperCollectionElement();
         mapper.switchIframeBack();
+    }
+
+    @When("^open data mapper unnamed collection mappings$")
+    public void openUnnamedCollectionMappings() {
+        mapper.openDataMapperUnnamedCollectionElement();
     }
 
     @Then("^check visibility of data mapper ui$")


### PR DESCRIPTION
we don't want to open all collections automatically - only unnamed ones
if we automatically open all collections, there might be field names collision

on the contrary, if we want to open *all* collections, there is distinct
step for that

//test: `@data-buckets-check-popups or @email-receive or @gmail-receive or @integrations-twitter-to-db`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
