### PR TITLE
[UI] fix gmail (and maybe more) connection creation in firefox on react UI

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/connections/fragments/list/ConnectionsList.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/connections/fragments/list/ConnectionsList.java
@@ -53,7 +53,9 @@ public class ConnectionsList extends CardList {
     @Override
     public SelenideElement getItem(String title) {
         return $(By.cssSelector(String.format(Element.CONNECTION_CARD,
-            title.toLowerCase().replaceAll(" ", "-"))));
+            title.toLowerCase()
+                .replaceAll("\\s|\\)", "-")
+                .replaceAll("\\(", ""))));
     }
 
     @Override

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/connections/fragments/list/ConnectionsList.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/connections/fragments/list/ConnectionsList.java
@@ -19,6 +19,7 @@ public class ConnectionsList extends CardList {
     private static final class Element {
         public static final By TECH_PREVIEW = By.xpath("syndesis-card-tech-preview");
         public static final String CONNECTION_CARD = "div[data-testid=\"connection-card-%s-card\"]";
+        public static final String CONNECTION_TITLE = "h1[data-testid=\"connection-card-title\"]";
         public static String KEBAB_MENU_SELECTOR = "[id=\"connection-%s-menu\"]";
 
     }
@@ -38,6 +39,12 @@ public class ConnectionsList extends CardList {
                 TestUtils.sleepForJenkinsDelayIfHigher(3);
                 new ModalDialogPage().getButton("Delete").shouldBe(visible).click();
                 break;
+            case CLICK:
+                getItem(title)
+                    .find(By.cssSelector(Element.CONNECTION_TITLE))
+                    .shouldBe(visible)
+                    .click();
+                break;
             default:
                 super.invokeActionOnItem(title, action);
         }
@@ -45,7 +52,8 @@ public class ConnectionsList extends CardList {
 
     @Override
     public SelenideElement getItem(String title) {
-        return $(By.cssSelector(String.format(Element.CONNECTION_CARD, title.toLowerCase().replaceAll(" ", "-"))));
+        return $(By.cssSelector(String.format(Element.CONNECTION_CARD,
+            title.toLowerCase().replaceAll(" ", "-"))));
     }
 
     @Override


### PR DESCRIPTION
This fixes the problem with firefox being unable to create a `gmail` connection because clickable area is smaller than the whole connection card firefox is clicking on.

//skip-ci
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
