### PR TITLE
[FUSEQE-4299] fix databucket tests with new react UI

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/SyndesisPageObject.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/SyndesisPageObject.java
@@ -191,7 +191,7 @@ public abstract class SyndesisPageObject {
         if (input.getAttribute("type").equals("checkbox")) {
             input.setSelected(Boolean.valueOf(value));
         } else {
-            input.sendKeys(Keys.chord(Keys.CONTROL, "a"));
+            input.sendKeys(Keys.chord(Keys.SHIFT, Keys.HOME));
             input.sendKeys(Keys.BACK_SPACE);
             input.shouldBe(visible).clear();
             input.shouldBe(visible).sendKeys(value);

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -300,7 +300,7 @@ public class DataMapper extends SyndesisPageObject {
     }
 
     public SelenideElement getDataBucketElement(String bucketName) {
-        return getRootElement().$(By.id(bucketName)).shouldBe(visible);
+        return $(By.id(bucketName)).shouldBe(visible);
     }
 
     public void openBucket(String bucketName) {

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -1,24 +1,27 @@
 package io.syndesis.qe.pages.integrations.editor.add.steps;
 
-import com.codeborne.selenide.ElementsCollection;
-import com.codeborne.selenide.Selenide;
-import com.codeborne.selenide.SelenideElement;
-import com.codeborne.selenide.WebDriverRunner;
-import io.syndesis.qe.pages.SyndesisPageObject;
-import io.syndesis.qe.utils.TestUtils;
-import lombok.extern.slf4j.Slf4j;
-import org.openqa.selenium.By;
-import org.openqa.selenium.Keys;
-import org.openqa.selenium.interactions.Actions;
-
-import java.util.Arrays;
-import java.util.List;
-
 import static com.codeborne.selenide.CollectionCondition.size;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 import static com.codeborne.selenide.Selenide.switchTo;
+
+import io.syndesis.qe.pages.SyndesisPageObject;
+import io.syndesis.qe.utils.TestUtils;
+
+import org.openqa.selenium.By;
+import org.openqa.selenium.Keys;
+import org.openqa.selenium.interactions.Actions;
+
+import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.Selenide;
+import com.codeborne.selenide.SelenideElement;
+import com.codeborne.selenide.WebDriverRunner;
+
+import java.util.Arrays;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Created by sveres on 11/14/17.

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
@@ -39,11 +39,8 @@ public class IntegrationFlowView extends SyndesisPageObject {
 
         public static final By POPOVER_CLASS = By.className("popover-content");
         public static final By STEP_DETAILS = By.className("list-view-pf-body");
-        public static final By DATA_WARNING_CLASS = By.className("data-mismatch");
         public static final By DATA_WARNING_BUTTON =
             By.cssSelector("button[data-testid=\"integration-editor-steps-list-item-warning-button\"]");
-        public static final By DATA_WARNING_TEXT =
-            By.cssSelector("a[data-testid=\"integration-editor-step-adder-add-step-before-connection-link\"]");
 
         public static final By FLOW_TITLE = By.cssSelector(".step.start .step-name");
 
@@ -51,8 +48,7 @@ public class IntegrationFlowView extends SyndesisPageObject {
 
         public static final By DELETE_BUTTON = By.cssSelector(".modal-footer .btn-danger");
 
-        public static final By STEP =
-            By.cssSelector("div.list-group-item");
+        public static final By STEP = By.cssSelector("div.list-group-item");
 
     }
 

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
@@ -31,22 +31,27 @@ public class IntegrationFlowView extends SyndesisPageObject {
         public static final By ROOT = By.cssSelector(".integration-vertical-flow__body");
 
         public static final By NAME = By.cssSelector("input.form-control.integration-name");
-        public static final By STEP_ROOT = By.cssSelector("div.flow-view-step");
-        public static final By STEP = By.cssSelector("div.parent-step");
         public static final By STEP_TITLE = By.cssSelector("div.step-name.syn-truncate__ellipsis");
         public static final By ACTIVE_STEP_ICON = By.cssSelector(".integration-flow-step-details.is-active");
         public static final By DELETE = By.className("delete-icon");
         public static final By STEP_INSERT = By.cssSelector("*[data-testid=\"integration-flow-add-step-add-step-link\"]");
 
-        public static final By POPOVER_CLASS = By.className("popover");
-        public static final By STEP_DETAILS = By.className("step-details");
+        public static final By POPOVER_CLASS = By.className("popover-content");
+        public static final By STEP_DETAILS = By.className("list-view-pf-body");
         public static final By DATA_WARNING_CLASS = By.className("data-mismatch");
+        public static final By DATA_WARNING_BUTTON =
+            By.cssSelector("button[data-testid=\"integration-editor-steps-list-item-warning-button\"]");
+        public static final By DATA_WARNING_TEXT =
+            By.cssSelector("a[data-testid=\"integration-editor-step-adder-add-step-before-connection-link\"]");
 
         public static final By FLOW_TITLE = By.cssSelector(".step.start .step-name");
 
         public static final By TRASH = By.className("fa-trash");
 
         public static final By DELETE_BUTTON = By.cssSelector(".modal-footer .btn-danger");
+
+        public static final By STEP =
+            By.cssSelector("div.list-group-item");
 
     }
 
@@ -169,11 +174,11 @@ public class IntegrationFlowView extends SyndesisPageObject {
      * @return
      */
     public SelenideElement getStepWarningElement(int stepPosition) {
-        return getStepOnPosition(stepPosition).$(Element.DATA_WARNING_CLASS);
+        return getStepOnPosition(stepPosition).$(Element.DATA_WARNING_BUTTON);
     }
 
     public SelenideElement getStepOnPosition(int position) {
-        return $$(By.className("list-group-item")).shouldBe(sizeGreaterThanOrEqual(position))
+        return $$(Element.STEP).shouldBe(sizeGreaterThanOrEqual(position))
                 .get(position - 1).shouldBe(visible);
     }
 
@@ -184,7 +189,8 @@ public class IntegrationFlowView extends SyndesisPageObject {
     }
 
     public String getPopoverText() {
-        String text = $(Element.POPOVER_CLASS).shouldBe(visible).getText();
+        SelenideElement textElement = $(Element.POPOVER_CLASS);
+        String text = textElement.find(Element.DATA_WARNING_TEXT).shouldBe(visible).text();
         log.info("Text found: " + text);
         return text;
     }

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
@@ -6,6 +6,9 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 import static com.codeborne.selenide.Selenide.$$;
 
+import io.syndesis.qe.pages.SyndesisPageObject;
+import io.syndesis.qe.pages.integrations.editor.add.steps.getridof.StepFactory;
+
 import org.openqa.selenium.By;
 
 import com.codeborne.selenide.ElementsCollection;
@@ -15,8 +18,6 @@ import com.codeborne.selenide.SelenideElement;
 import java.util.ArrayList;
 import java.util.List;
 
-import io.syndesis.qe.pages.SyndesisPageObject;
-import io.syndesis.qe.pages.integrations.editor.add.steps.getridof.StepFactory;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -56,8 +57,8 @@ public class IntegrationFlowView extends SyndesisPageObject {
     }
 
     private static final class Button {
-        public static final By Expand = By.cssSelector("button.btn.btn-default.toggle-collapsed.collapsed");
-        public static final By Collapse = By.cssSelector("button.btn.btn-default.toggle-collapsed:not(.collapsed)");
+        public static final By EXPAND = By.cssSelector("button.btn.btn-default.toggle-collapsed.collapsed");
+        public static final By COLLAPSE = By.cssSelector("button.btn.btn-default.toggle-collapsed:not(.collapsed)");
     }
 
     private StepFactory stepComponentFactory = new StepFactory();
@@ -89,7 +90,7 @@ public class IntegrationFlowView extends SyndesisPageObject {
 
     public List<String> getStepsTitlesArray() {
         if (isCollapsed()) {
-            $(Button.Expand).click();
+            $(Button.EXPAND).click();
         }
 
         ElementsCollection steps = this.getRootElement().findAll(Element.STEP);
@@ -102,7 +103,7 @@ public class IntegrationFlowView extends SyndesisPageObject {
             stepsArray.add(title.getAttribute("title"));
         }
         if (isExpanded()) {
-            $(Button.Collapse).click();
+            $(Button.COLLAPSE).click();
         }
         return stepsArray;
     }
@@ -142,7 +143,7 @@ public class IntegrationFlowView extends SyndesisPageObject {
      */
     public String checkTextInHoverTable(String stepPosition) {
         String text;
-        if (stepPosition.equalsIgnoreCase("middle")) {
+        if ("middle".equalsIgnoreCase(stepPosition)) {
             // This is ugly but for now it works - it has only one usage: for getting our data-mapper step
             // which is between start and finish step.
             // Explanation: we have 3 steps and between them 2 elements with insert step option --> 5 total
@@ -216,10 +217,10 @@ public class IntegrationFlowView extends SyndesisPageObject {
     }
 
     public boolean isCollapsed() {
-        return $(Button.Expand).exists();
+        return $(Button.EXPAND).exists();
     }
 
     public boolean isExpanded() {
-        return $(Button.Collapse).exists();
+        return $(Button.COLLAPSE).exists();
     }
 }

--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/fragments/IntegrationFlowView.java
@@ -190,8 +190,7 @@ public class IntegrationFlowView extends SyndesisPageObject {
     }
 
     public String getPopoverText() {
-        SelenideElement textElement = $(Element.POPOVER_CLASS);
-        String text = textElement.find(Element.DATA_WARNING_TEXT).shouldBe(visible).text();
+        String text = $(Element.POPOVER_CLASS).shouldBe(visible).text();
         log.info("Text found: " + text);
         return text;
     }

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/IntegrationSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/IntegrationSteps.java
@@ -151,16 +151,21 @@ public class IntegrationSteps {
     @And("^.*open data bucket \"([^\"]*)\"$")
     public void openDataBucket(String bucket) {
         //check if it exists included
+        dataMapper.switchToDatamapperIframe();
         dataMapper.openBucket(bucket);
+        dataMapper.switchIframeBack();
     }
 
     @And("^.*close data bucket \"([^\"]*)\"$")
     public void closeDataBucket(String bucket) {
+        dataMapper.switchToDatamapperIframe();
         dataMapper.closeBucket(bucket);
+        dataMapper.switchIframeBack();
     }
 
     @And("^.*perform action with data bucket")
     public void performActionWithBucket(DataTable table) {
+        dataMapper.switchToDatamapperIframe();
         List<List<String>> rows = table.cells();
         String action;
 
@@ -175,6 +180,7 @@ public class IntegrationSteps {
                 dataMapper.getDataBucketElement(row.get(0));
             }
         }
+        dataMapper.switchIframeBack();
     }
 
     @Then("^.*validate that logs of integration \"([^\"]*)\" contains string \"(.*)\"$")

--- a/ui-tests/src/test/resources/features/integrations/data-buckets.feature
+++ b/ui-tests/src/test/resources/features/integrations/data-buckets.feature
@@ -31,21 +31,22 @@ Feature: Integration - Databucket
 
     When select the "Twitter Listener" connection
     And select "Mention" integration action
+    And click on the "Next" button
     Then check that position of connection to fill is "Finish"
     And check visibility of page "Choose a Finish Connection"
 
     When select the "PostgresDB" connection
     And select "Invoke SQL" integration action
     Then fill in invoke query input with "UPDATE TODO SET completed=1 WHERE TASK = :#TASK" value
-    And click on the "Done" button
-    And check that text "Add a data mapping step" is "visible" in step warning inside of step number "3"
+    And click on the "Next" button
+    And check that text "Add a data mapping step" is "visible" in step warning inside of step number "2"
     And check that there is no warning inside of step number "1"
 
     When open integration flow details
     Then check that in connection info popover for step number "1" is following text
-      | Twitter Listener | Action | Mention | Data Type | Twitter Mention |
-    And check that in connection info popover for step number "3" is following text
-      | PostgresDB | Action | Invoke SQL | Data Type | SQL Parameter |
+      | Action | Mention | Data Type | Twitter Mention |
+    And check that in connection info popover for step number "2" is following text
+      | Action | Invoke SQL | Data Type | SQL Parameter |
 
     When add integration step on position "0"
     And select "Data Mapper" integration step
@@ -57,12 +58,12 @@ Feature: Integration - Databucket
     And click on the "Done" button
     And open integration flow details
     Then check that in connection info popover for step number "1" is following text
-      | Twitter Listener | Action | Mention | Data Type | Twitter Mention |
-    And check that in connection info popover for step number "5" is following text
-      | PostgresDB | Action | Invoke SQL | Data Type | SQL Parameter |
-    And check that there is no warning inside of step number "5"
-    And check that there is no warning inside of step number "1"
+      | Action | Mention | Data Type | Twitter Mention |
+    And check that in connection info popover for step number "3" is following text
+      | Action | Invoke SQL | Data Type | SQL Parameter |
     And check that there is no warning inside of step number "3"
+    And check that there is no warning inside of step number "1"
+    And check that there is no warning inside of step number "2"
 
 #
 #  2. check that data buckets are available
@@ -87,7 +88,7 @@ Feature: Integration - Databucket
 
     When select the "My GMail Connector" connection
     And select "Send Email" integration action
-    And fill in values
+    And fill in values by element ID
       | Email to | jbossqa.fuse@gmail.com |
     And click on the "Done" button
 
@@ -100,8 +101,8 @@ Feature: Integration - Databucket
 
     #And check that there is no warning inside of step number "2"
     When open integration flow details
-    Then check that in connection info popover for step number "3" is following text
-      | Name | PostgresDB | Action | Invoke SQL | Data Type | SQL Result |
+    Then check that in connection info popover for step number "2" is following text
+      | Action | Invoke SQL | Data Type | n/a |
 
     When add integration step on position "1"
     And select "Data Mapper" integration step
@@ -115,7 +116,7 @@ Feature: Integration - Databucket
       | firma   | subject |
     And scroll "top" "right"
     And click on the "Done" button
-    Then check that there is no warning inside of step number "5"
+    Then check that there is no warning inside of step number "3"
 
     When click on the "Save" link
     And set integration name "Integration_with_buckets"
@@ -191,7 +192,7 @@ Feature: Integration - Databucket
 
     Then check that there is no warning inside of step number "1"
     And check that text "Add a data mapping step" is "visible" in step warning inside of steps
-      | 3 | 5 | 7 | 9 | 11 |
+      | 2 | 3 | 4 | 5 | 6 |
 
     ##################### mappings ##################################
     #################################################################


### PR DESCRIPTION
This fixes databucket tests for the new react UI.
The only test that doesn't work yet, is `@data-buckets-usage`, due to datamapper problems (https://github.com/syndesisio/syndesis/issues/5622).
When datamapper bug gets fixed, all databucket tests should pass.

//test: `@data-buckets-check-popups or @data-buckets-usage-2`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
