### PR TITLE
[FUSEQE-4853] Add a simple reachability check

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/utils/HttpUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/HttpUtils.java
@@ -57,8 +57,8 @@ public final class HttpUtils {
 
     public static HTTPResponse doPostRequest(String url, RequestBody body, Headers headers) {
         Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .post(body);
+            .url(url)
+            .post(body);
         if (headers != null) {
             requestBuilder.headers(headers);
         }
@@ -72,8 +72,8 @@ public final class HttpUtils {
 
     public static HTTPResponse doGetRequest(String url, Headers headers) {
         Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .get();
+            .url(url)
+            .get();
         if (headers != null) {
             requestBuilder.headers(headers);
         }
@@ -87,8 +87,8 @@ public final class HttpUtils {
 
     public static HTTPResponse doDeleteRequest(String url, Headers headers) {
         Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .delete();
+            .url(url)
+            .delete();
         if (headers != null) {
             requestBuilder.headers(headers);
         }
@@ -107,8 +107,8 @@ public final class HttpUtils {
     public static HTTPResponse doPutRequest(String url, String content, String contentType, Headers headers) {
         RequestBody body = RequestBody.create(MediaType.parse(contentType), content);
         Request.Builder requestBuilder = new Request.Builder()
-                .url(url)
-                .put(body);
+            .url(url)
+            .put(body);
         if (headers != null) {
             requestBuilder.headers(headers);
         }
@@ -116,23 +116,40 @@ public final class HttpUtils {
         return doRequest(requestBuilder.build());
     }
 
+    /**
+     * Check if the url is reachable.
+     * @param url url to check
+     * @return true if there is any response, false if there is an exception raised
+     */
+    public static boolean isReachable(String url) {
+        Request.Builder requestBuilder = new Request.Builder()
+            .url(url)
+            .get();
+        try {
+            getClient().newCall(requestBuilder.build()).execute();
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
     private static OkHttpClient getClient() {
         // Create a trust manager that does not validate certificate chains
-        final TrustManager[] trustAllCerts = new TrustManager[]{
-                new X509TrustManager() {
-                    @Override
-                    public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                    }
-
-                    @Override
-                    public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
-                    }
-
-                    @Override
-                    public java.security.cert.X509Certificate[] getAcceptedIssuers() {
-                        return new java.security.cert.X509Certificate[]{};
-                    }
+        final TrustManager[] trustAllCerts = new TrustManager[] {
+            new X509TrustManager() {
+                @Override
+                public void checkClientTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
                 }
+
+                @Override
+                public void checkServerTrusted(java.security.cert.X509Certificate[] chain, String authType) throws CertificateException {
+                }
+
+                @Override
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                    return new java.security.cert.X509Certificate[] {};
+                }
+            }
         };
 
         // Install the all-trusting trust manager
@@ -145,10 +162,10 @@ public final class HttpUtils {
             builder.sslSocketFactory(sslSocketFactory, (X509TrustManager) trustAllCerts[0]);
             builder.hostnameVerifier((hostname, session) -> true);
             return builder
-                    .connectTimeout(15, TimeUnit.SECONDS)
-                    .writeTimeout(15, TimeUnit.SECONDS)
-                    .readTimeout(15, TimeUnit.SECONDS)
-                    .build();
+                .connectTimeout(15, TimeUnit.SECONDS)
+                .writeTimeout(15, TimeUnit.SECONDS)
+                .readTimeout(15, TimeUnit.SECONDS)
+                .build();
         } catch (NoSuchAlgorithmException | KeyManagementException e) {
             fail("Error while creating Http client", e);
         }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
Add a check if the openshift cluster is reachable by a simple GET request to the api endpoint in the `resetDB` method as it should be present in (almost) all tests. 

So if the network goes down during a test, the next test will wait (up to 30 minutes) until the api is reachable again, because the current situation is that when the network is down, all tests will fail on resetDB in the matter of seconds :grin:  

There is a slight probability that if the cluster won't respond, the tests will take `countOfTests*30` minutes to finish, but we should notice it sooner :grin: 

@tplevko @asmigala wdyt?