### PR TITLE
[FUSEQE-4857] Changes needed to work with newer openshift-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,8 @@
 		<amazon.sdk.version>1.11.257</amazon.sdk.version>
 		<commons-lang3.version>3.7</commons-lang3.version>
 		<webdriverextensions.version>3.1.3</webdriverextensions.version>
-		<xtf.utilities.version>0.9</xtf.utilities.version>
+		<!-- version >= 0.13 is needed to be compatible with newer client -->
+		<xtf.utilities.version>0.13-SNAPSHOT</xtf.utilities.version>
 		<ftp.client.version>3.3</ftp.client.version>
 		<dropbox.core.sdk.version>3.0.6</dropbox.core.sdk.version>
 		<activemq.version>5.15.9</activemq.version>
@@ -59,6 +60,7 @@
 		<box.version>2.30.1</box.version>
 		<jsoup.version>1.11.3</jsoup.version>
 		<aws.sqs.version>2.5.29</aws.sqs.version>
+		<openshift.client.version>4.3.0</openshift.client.version>
 
 		<!-- leave driver versions empty to use latest driver -->
 		<!-- Find supported webdriver version for your chrome browser here:
@@ -108,18 +110,8 @@
 
 			<dependency>
 				<groupId>cz.xtf</groupId>
-				<artifactId>utilities</artifactId>
+				<artifactId>core</artifactId>
 				<version>${xtf.utilities.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId> org.seleniumhq.selenium</groupId>
-						<artifactId>selenium-java</artifactId>
-					</exclusion>
-					<exclusion>
-						<groupId> org.seleniumhq.selenium</groupId>
-						<artifactId>selenium-remote-driver</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 
 			<dependency>
@@ -428,6 +420,12 @@
 				<groupId>software.amazon.awssdk</groupId>
 				<artifactId>sqs</artifactId>
 				<version>${aws.sqs.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>io.fabric8</groupId>
+				<artifactId>openshift-client</artifactId>
+				<version>${openshift.client.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>

--- a/rest-tests/src/test/java/io/syndesis/qe/RestTestHooks.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/RestTestHooks.java
@@ -71,7 +71,7 @@ public class RestTestHooks {
             TestUtils.printPods();
             log.warn("Scenario {} failed, saving integration logs to scenario", scenario.getName());
             // There can be multiple integration pods for one test
-            List<Pod> integrationPods = OpenShiftUtils.client().pods().list().getItems().stream().filter(
+            List<Pod> integrationPods = OpenShiftUtils.getInstance().pods().list().getItems().stream().filter(
                 p -> p.getMetadata().getName().startsWith("i-")
                     && !p.getMetadata().getName().contains("deploy")
                     && !p.getMetadata().getName().contains("build")

--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/state/IntegrationStateHandler.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/state/IntegrationStateHandler.java
@@ -2,14 +2,15 @@ package io.syndesis.qe.rest.tests.steps.state;
 
 import static org.assertj.core.api.Fail.fail;
 
+import io.syndesis.qe.endpoints.IntegrationsEndpoint;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
 import cucumber.api.java.en.When;
-import io.syndesis.qe.endpoints.IntegrationsEndpoint;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
 
 public class IntegrationStateHandler {
     @Autowired
@@ -27,9 +28,9 @@ public class IntegrationStateHandler {
         int retries = 0;
         boolean buildPodPresent = false;
         while (!buildPodPresent && retries < maxRetries) {
-            buildPodPresent = OpenShiftUtils.client().pods().list().getItems().stream().anyMatch(
-                    p -> p.getMetadata().getName().contains(name.toLowerCase().replaceAll(" ", "-"))
-                            && p.getMetadata().getName().endsWith("-build"));
+            buildPodPresent = OpenShiftUtils.getInstance().pods().list().getItems().stream().anyMatch(
+                p -> p.getMetadata().getName().contains(name.toLowerCase().replaceAll(" ", "-"))
+                    && p.getMetadata().getName().endsWith("-build"));
             TestUtils.sleepIgnoreInterrupt(10000L);
             retries++;
         }

--- a/utilities/pom.xml
+++ b/utilities/pom.xml
@@ -11,10 +11,14 @@
 	<artifactId>utilities</artifactId>
 
 	<dependencies>
+		<dependency>
+			<groupId>io.fabric8</groupId>
+			<artifactId>openshift-client</artifactId>
+		</dependency>
 
 		<dependency>
 			<groupId>cz.xtf</groupId>
-			<artifactId>utilities</artifactId>
+			<artifactId>core</artifactId>
 		</dependency>
 
 		<dependency>

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -1,5 +1,7 @@
 package io.syndesis.qe;
 
+import io.syndesis.qe.utils.TestUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -8,7 +10,6 @@ import java.nio.file.Paths;
 import java.util.Optional;
 import java.util.Properties;
 
-import io.syndesis.qe.utils.TestUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -90,32 +91,58 @@ public class TestConfiguration {
         return get().readValue(OPENSHIFT_URL);
     }
 
-    public static String openShiftToken() { return get().readValue(OPENSHIFT_TOKEN); }
+    public static String openShiftToken() {
+        return get().readValue(OPENSHIFT_TOKEN);
+    }
 
-    public static String openShiftNamespace() { return get().readValue(OPENSHIFT_NAMESPACE); }
+    public static String openShiftNamespace() {
+        return get().readValue(OPENSHIFT_NAMESPACE);
+    }
 
     // Namespace for the subject access review. If unspecified, will use the same namespace as for the deployment.
-    public static String openShiftSARNamespace() { return get().readValue(OPENSHIFT_SAR_NAMESPACE, get().readValue(OPENSHIFT_NAMESPACE)); }
+    public static String openShiftSARNamespace() {
+        return get().readValue(OPENSHIFT_SAR_NAMESPACE, get().readValue(OPENSHIFT_NAMESPACE));
+    }
 
-    public static String openShiftRouteSuffix() { return get().readValue(OPENSHIFT_ROUTE_SUFFIX); }
+    public static String openShiftRouteSuffix() {
+        return get().readValue(OPENSHIFT_ROUTE_SUFFIX);
+    }
 
-    public static String syndesisUsername() { return get().readValue(SYNDESIS_UI_USERNAME); }
+    public static String syndesisUsername() {
+        return get().readValue(SYNDESIS_UI_USERNAME);
+    }
 
-    public static String syndesisPassword() { return get().readValue(SYNDESIS_UI_PASSWORD); }
+    public static String syndesisPassword() {
+        return get().readValue(SYNDESIS_UI_PASSWORD);
+    }
 
-    public static String syndesisUrl() { return get().readValue(SYNDESIS_UI_URL); }
+    public static String syndesisUrl() {
+        return get().readValue(SYNDESIS_UI_URL);
+    }
 
-    public static String syndesisCallbackUrlSuffix() { return get().readValue(SYNDESIS_CALLBACK_URL_SUFFIX); }
+    public static String syndesisCallbackUrlSuffix() {
+        return get().readValue(SYNDESIS_CALLBACK_URL_SUFFIX);
+    }
 
-    public static String syndesisRestApiPath() { return get().readValue(SYNDESIS_REST_API_PATH); }
+    public static String syndesisRestApiPath() {
+        return get().readValue(SYNDESIS_REST_API_PATH);
+    }
 
-    public static String syndesisCredentialsFile() { return get().readValue(SYNDESIS_CREDENTIALS_FILE); }
+    public static String syndesisCredentialsFile() {
+        return get().readValue(SYNDESIS_CREDENTIALS_FILE);
+    }
 
-    public static String syndesisVersionsFile() { return get().readValue(SYNDESIS_VERSIONS_FILE); }
+    public static String syndesisVersionsFile() {
+        return get().readValue(SYNDESIS_VERSIONS_FILE);
+    }
 
-    public static String syndesisTemplateUrl() { return get().readValue(SYNDESIS_TEMPLATE_URL); }
+    public static String syndesisTemplateUrl() {
+        return get().readValue(SYNDESIS_TEMPLATE_URL);
+    }
 
-    public static String syndesisTemplateSA() { return get().readValue(SYNDESIS_TEMPLATE_SA); }
+    public static String syndesisTemplateSA() {
+        return get().readValue(SYNDESIS_TEMPLATE_SA);
+    }
 
     public static String syndesisPublicOauthProxyTemplateUrl() {
         return get().readValue(SYNDESIS_PUBLIC_OAUTH_PROXY_URL);
@@ -141,25 +168,41 @@ public class TestConfiguration {
         return get().readValue(SYNDESIS_OPERATOR_TEMPLATE_URL);
     }
 
-    public static String syndesisBrowser() { return get().readValue(SYNDESIS_UI_BROWSER); }
+    public static String syndesisBrowser() {
+        return get().readValue(SYNDESIS_UI_BROWSER);
+    }
 
-    public static boolean namespaceCleanup() { return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_CLEANUP)); }
+    public static boolean namespaceCleanup() {
+        return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_CLEANUP));
+    }
 
-    public static boolean namespaceCleanupAfter() { return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_CLEANUP_AFTER)); }
+    public static boolean namespaceCleanupAfter() {
+        return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_CLEANUP_AFTER));
+    }
 
-    public static boolean namespaceLock() { return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_LOCK)); }
+    public static boolean namespaceLock() {
+        return Boolean.parseBoolean(get().readValue(OPENSHIFT_NAMESPACE_LOCK));
+    }
 
-    public static boolean useServerRoute() { return Boolean.parseBoolean(get().readValue(SYNDESIS_SERVER_ROUTE)); }
+    public static boolean useServerRoute() {
+        return Boolean.parseBoolean(get().readValue(SYNDESIS_SERVER_ROUTE));
+    }
 
     public static String customResourcePlural() {
         return get().readValue(SYNDESIS_CUSTOM_RESOURCE_PLURAL);
     }
 
-    public static int getJenkinsDelay() { return Integer.parseInt(get().readValue(JENKINS_DELAY, "1")); }
+    public static int getJenkinsDelay() {
+        return Integer.parseInt(get().readValue(JENKINS_DELAY, "1"));
+    }
 
-    public static int getConfigTimeout() {return Integer.parseInt(get().readValue(TESTSUITE_TIMEOUT, "30")); }
+    public static int getConfigTimeout() {
+        return Integer.parseInt(get().readValue(TESTSUITE_TIMEOUT, "30"));
+    }
 
-    public static String getDbAllocatorUrl(){ return get().readValue(DB_ALLOCATOR_URL, "localhost:8080"); }
+    public static String getDbAllocatorUrl() {
+        return get().readValue(DB_ALLOCATOR_URL, "localhost:8080");
+    }
 
     public static String prodRepository() {
         return get().readValue(PROD_REPOSITORY);
@@ -207,29 +250,36 @@ public class TestConfiguration {
         }
 
         if (props.getProperty(SYNDESIS_TEMPLATE_URL) == null) {
-            props.setProperty(SYNDESIS_TEMPLATE_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/syndesis.yml", syndesisVersion));
+            props.setProperty(SYNDESIS_TEMPLATE_URL,
+                String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/syndesis.yml", syndesisVersion));
         }
         if (props.getProperty(SYNDESIS_OPERATOR_URL) == null) {
-            props.setProperty(SYNDESIS_OPERATOR_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-operator.yml", syndesisVersion));
+            props.setProperty(SYNDESIS_OPERATOR_URL, String
+                .format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-operator.yml", syndesisVersion));
         }
         if (props.getProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL) == null) {
-            props.setProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/support/syndesis-public-oauth-proxy.yml", syndesisVersion));
+            props.setProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL, String
+                .format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/support/syndesis-public-oauth-proxy.yml", syndesisVersion));
         }
 
-        props.setProperty(SYNDESIS_OPERATOR_CRD_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-crd.yml", syndesisVersion));
-        props.setProperty(SYNDESIS_OPERATOR_TEMPLATE_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis.yml", syndesisVersion));
+        props.setProperty(SYNDESIS_OPERATOR_CRD_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-crd.yml", syndesisVersion));
+        props.setProperty(SYNDESIS_OPERATOR_TEMPLATE_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis.yml", syndesisVersion));
 
         props.setProperty(SYNDESIS_TEMPLATE_USE_OPERATOR, "true");
 
         props.setProperty(SYNDESIS_CUSTOM_RESOURCE_PLURAL, "syndesises");
 
         // Copy syndesis properties to their xtf counterparts - used by binary oc client
-        System.setProperty("xtf.config.master.url", properties.getProperty(OPENSHIFT_URL));
-        System.setProperty("xtf.config.master.username", properties.getProperty(SYNDESIS_UI_USERNAME));
-        System.setProperty("xtf.config.master.password", properties.getProperty(SYNDESIS_UI_PASSWORD));
+        System.setProperty("xtf.openshift.url", properties.getProperty(OPENSHIFT_URL));
+        System.setProperty("xtf.openshift.master.username", properties.getProperty(SYNDESIS_UI_USERNAME));
+        System.setProperty("xtf.openshift.master.password", properties.getProperty(SYNDESIS_UI_PASSWORD));
+        System.setProperty("xtf.openshift.master.token", properties.getProperty(OPENSHIFT_TOKEN));
+        System.setProperty("xtf.openshift.namespace", properties.getProperty(OPENSHIFT_NAMESPACE));
 
         // Set oc version - this version of the client will be used as the binary client
-        System.setProperty("xtf.config.openshift.version", "3.10.70");
+        System.setProperty("xtf.openshift.version", "3.10.70");
         return props;
     }
 
@@ -245,7 +295,7 @@ public class TestConfiguration {
         final Properties props = new Properties();
 
         final Path propsPath = Paths.get(path)
-                .toAbsolutePath();
+            .toAbsolutePath();
         if (Files.isReadable(propsPath)) {
             try (InputStream is = Files.newInputStream(propsPath)) {
                 props.load(is);
@@ -264,24 +314,30 @@ public class TestConfiguration {
 
     private void copyValues(final Properties source, final boolean overwrite) {
         source.stringPropertyNames().stream()
-                .filter(key -> overwrite || !this.properties.containsKey(key))
-                .forEach(key -> this.properties.setProperty(key, source.getProperty(key)));
+            .filter(key -> overwrite || !this.properties.containsKey(key))
+            .forEach(key -> this.properties.setProperty(key, source.getProperty(key)));
     }
 
     /**
      * Used to override syndesis version when the property is defined later than TestConfiguration is initialized.
+     *
      * @param version syndesis version
      */
     public void overrideSyndesisVersion(String version) {
-        properties.setProperty(SYNDESIS_TEMPLATE_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/syndesis.yml", version));
-        properties.setProperty(SYNDESIS_TEMPLATE_SA, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/support/serviceaccount-as-oauthclient-restricted.yml", version));
-        properties.setProperty(SYNDESIS_OPERATOR_CRD_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-crd.yml", version));
-        properties.setProperty(SYNDESIS_OPERATOR_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-operator.yml", version));
-        properties.setProperty(SYNDESIS_OPERATOR_TEMPLATE_URL, String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis.yml", version));
+        properties.setProperty(SYNDESIS_TEMPLATE_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/syndesis.yml", version));
+        properties.setProperty(SYNDESIS_TEMPLATE_SA, String
+            .format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/support/serviceaccount-as-oauthclient-restricted.yml",
+                version));
+        properties.setProperty(SYNDESIS_OPERATOR_CRD_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-crd.yml", version));
+        properties.setProperty(SYNDESIS_OPERATOR_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis-operator.yml", version));
+        properties.setProperty(SYNDESIS_OPERATOR_TEMPLATE_URL,
+            String.format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/operator/deploy/syndesis.yml", version));
     }
 
     public static Optional<String> browserBinary() {
         return Optional.ofNullable(get().readValue(BROWSER_BINARY_PATH));
     }
-
 }

--- a/utilities/src/main/java/io/syndesis/qe/TestSuiteParent.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestSuiteParent.java
@@ -52,7 +52,7 @@ public abstract class TestSuiteParent {
         }
         cleanNamespace();
         log.info("Creating namespace lock via secret `test-lock`");
-        lockSecret = OpenShiftUtils.client().secrets()
+        lockSecret = OpenShiftUtils.getInstance().secrets()
             .createOrReplaceWithNew()
             .withNewMetadata()
             .withName("test-lock")

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/CommonValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/CommonValidationSteps.java
@@ -3,6 +3,16 @@ package io.syndesis.qe.bdd.validation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
+import io.syndesis.common.model.integration.Integration;
+import io.syndesis.common.model.integration.IntegrationDeployment;
+import io.syndesis.common.model.integration.IntegrationDeploymentState;
+import io.syndesis.qe.endpoints.IntegrationOverviewEndpoint;
+import io.syndesis.qe.endpoints.IntegrationsEndpoint;
+import io.syndesis.qe.model.IntegrationOverview;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.ArrayList;
@@ -14,15 +24,6 @@ import java.util.stream.Collectors;
 import cucumber.api.java.en.Then;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.openshift.api.model.Build;
-import io.syndesis.common.model.integration.Integration;
-import io.syndesis.common.model.integration.IntegrationDeployment;
-import io.syndesis.common.model.integration.IntegrationDeploymentState;
-import io.syndesis.qe.endpoints.IntegrationOverviewEndpoint;
-import io.syndesis.qe.endpoints.IntegrationsEndpoint;
-import io.syndesis.qe.model.IntegrationOverview;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
-import io.syndesis.qe.wait.OpenShiftWaitUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -54,18 +55,19 @@ public class CommonValidationSteps {
         if (!activated) {
             log.error("Integration was not active after 9 minutes");
             log.error("Pod list: ");
-            for (Pod pod : OpenShiftUtils.client().pods().list().getItems()) {
+            for (Pod pod : OpenShiftUtils.getInstance().pods().list().getItems()) {
                 log.error(pod.getMetadata().getName());
 
-                if(pod.getMetadata().getName().toLowerCase().contains(integrationName.replaceAll(" ", "-").toLowerCase())) {
+                if (pod.getMetadata().getName().toLowerCase().contains(integrationName.replaceAll(" ", "-").toLowerCase())) {
                     log.error("....................Printing integration pod info...................");
                     log.error(pod.toString());
-                    log.error(OpenShiftUtils.client().pods().withName(pod.getMetadata().getName()).getLog());
+                    log.error(OpenShiftUtils.getInstance().pods().withName(pod.getMetadata().getName()).getLog());
                 }
             }
         }
         assertThat(activated).isTrue();
-        log.info("Integration pod has been started. It took {}s to build the integration.", TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - start));
+        log.info("Integration pod has been started. It took {}s to build the integration.",
+            TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - start));
         if (TestUtils.isJenkins()) {
             log.info("Running on Jenkins, adding 2 min sleep");
             TestUtils.sleepIgnoreInterrupt(120000L);
@@ -84,7 +86,8 @@ public class CommonValidationSteps {
     @Then(value = "^verify there are no s2i builds running for integration: \"([^\"]*)\"$")
     public void verifyNoIntegrationBuildRunning(String integrationName) {
         final String sanitizedName = integrationName.toLowerCase().replaceAll(" ", "-");
-        assertThat(new ArrayList<>(OpenShiftUtils.getInstance().getBuilds())).filteredOn(build -> build.getMetadata().getLabels().get("buildconfig").contentEquals(sanitizedName)).isEmpty();
+        assertThat(new ArrayList<>(OpenShiftUtils.getInstance().getBuilds()))
+            .filteredOn(build -> build.getMetadata().getLabels().get("buildconfig").contentEquals(sanitizedName)).isEmpty();
         log.info("There is no builds with name {} running", sanitizedName);
     }
 
@@ -96,7 +99,7 @@ public class CommonValidationSteps {
     @Then("^verify that integration with name (\\w+) doesn't exist$")
     public void integrationNotExist(String integrationName) {
         assertThatExceptionOfType(NoSuchElementException.class)
-                .isThrownBy(() -> integrationsEndpoint.getIntegrationId(integrationName));
+            .isThrownBy(() -> integrationsEndpoint.getIntegrationId(integrationName));
     }
 
     @Then("^verify integration \"([^\"]*)\" has current state \"([^\"]*)\"")
@@ -129,7 +132,7 @@ public class CommonValidationSteps {
             log.error("Error: {}", ex);
         }
         final List<Pod> pods = OpenShiftUtils.getInstance().getPods().stream().filter(
-                b -> b.getMetadata().getName().contains(sanitizedName)).collect(Collectors.toList());
+            b -> b.getMetadata().getName().contains(sanitizedName)).collect(Collectors.toList());
         assertThat(pods.stream().filter(p -> p.getStatus().getPhase().contentEquals("Running")).count() == podCount);
         log.info("There are {} pods with name {} running", podCount, sanitizedName);
     }

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/JmsValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/JmsValidationSteps.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import io.syndesis.qe.utils.JMSUtils;
+import io.syndesis.qe.utils.JmsClient;
 import io.syndesis.qe.utils.JmsClientManager;
 
 import org.assertj.core.api.Assertions;
@@ -16,7 +17,6 @@ import java.nio.file.Files;
 import cucumber.api.java.en.Given;
 import cucumber.api.java.en.Then;
 import cucumber.api.java.en.When;
-import cz.xtf.jms.JmsClient;
 
 public class JmsValidationSteps {
 

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/ProdValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/ProdValidationSteps.java
@@ -3,8 +3,10 @@ package io.syndesis.qe.bdd.validation;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Fail.fail;
 
-import org.apache.commons.io.FileUtils;
+import io.syndesis.qe.TestConfiguration;
+import io.syndesis.qe.utils.OpenShiftUtils;
 
+import org.apache.commons.io.FileUtils;
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
@@ -17,9 +19,6 @@ import javax.xml.xpath.XPathFactory;
 import java.io.File;
 
 import cucumber.api.java.en.Then;
-import cz.xtf.openshift.OpenShiftBinaryClient;
-import io.syndesis.qe.TestConfiguration;
-import io.syndesis.qe.utils.OpenShiftUtils;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -37,12 +36,12 @@ public class ProdValidationSteps {
         final String integrationPodName = OpenShiftUtils.getPodByPartialName("i-").get().getMetadata().getName();
         log.info(integrationPodName);
         // It adds quotes around the command for exec and oc client doesn't understand that, so rsync the file instead
-        OpenShiftBinaryClient.getInstance().executeCommand("Unable to get integration's POM file",
-                "rsync",
-                "-n", TestConfiguration.openShiftNamespace(),
-                integrationPodName + ":/tmp/src/pom.xml",
-                "/tmp"
-                );
+        OpenShiftUtils.binary().execute(
+            "rsync",
+            "-n", TestConfiguration.openShiftNamespace(),
+            integrationPodName + ":/tmp/src/pom.xml",
+            "/tmp"
+        );
 
         DocumentBuilderFactory builderFactory = DocumentBuilderFactory.newInstance();
         try {
@@ -57,8 +56,8 @@ public class ProdValidationSteps {
         loadIntegrationXml();
         final XPath xPath = XPathFactory.newInstance().newXPath();
         try {
-            assertThat(((Node)xPath.compile("//project/properties/" + property).evaluate(pom, XPathConstants.NODE)).getTextContent())
-                    .contains("redhat");
+            assertThat(((Node) xPath.compile("//project/properties/" + property).evaluate(pom, XPathConstants.NODE)).getTextContent())
+                .contains("redhat");
         } catch (XPathExpressionException e) {
             fail("Unable to compile xpath expression: ", e);
         }

--- a/utilities/src/main/java/io/syndesis/qe/templates/FtpTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/FtpTemplate.java
@@ -1,5 +1,11 @@
 package io.syndesis.qe.templates;
 
+import io.syndesis.qe.accounts.Account;
+import io.syndesis.qe.accounts.AccountsDirectory;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -11,11 +17,6 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
-import io.syndesis.qe.accounts.Account;
-import io.syndesis.qe.accounts.AccountsDirectory;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
-import io.syndesis.qe.wait.OpenShiftWaitUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -40,7 +41,7 @@ public class FtpTemplate {
                 ports.add(dataPort);
             }
 
-            OpenShiftUtils.client().deploymentConfigs().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().deploymentConfigs().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)
@@ -81,7 +82,7 @@ public class FtpTemplate {
                         .build());
             }
 
-            OpenShiftUtils.getInstance().client().services().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().services().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)

--- a/utilities/src/main/java/io/syndesis/qe/templates/HTTPEndpointsTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/HTTPEndpointsTemplate.java
@@ -1,30 +1,31 @@
 package io.syndesis.qe.templates;
 
-import java.io.IOException;
-import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.concurrent.TimeoutException;
-
 import io.syndesis.qe.accounts.Account;
 import io.syndesis.qe.accounts.AccountsDirectory;
 import io.syndesis.qe.utils.OpenShiftUtils;
 import io.syndesis.qe.utils.TestUtils;
 import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class HTTPEndpointsTemplate {
-    private static final String TEMPLATE_URL = "https://raw.githubusercontent.com/avano/HTTPEndpoints/master/template.yml";
+    private static final String TEMPLATE_URL = "https://raw.githubusercontent.com/syndesisio/syndesis-qe-HTTPEndpoints/master/template.yml";
 
     public static void deploy() {
         if (!TestUtils.isDcDeployed("httpendpoints")) {
-            try {
-                OpenShiftUtils.client().load(new URL(TEMPLATE_URL).openStream()).createOrReplace();
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-
+            //OCP4HACK - openshift-client 4.3.0 isn't supported with OCP4 and can't create/delete templates, following lines can be removed later
+            OpenShiftUtils.binary().execute("create", "-f", TEMPLATE_URL);
+            OpenShiftUtils.binary().execute("new-app", "http-endpoints");
+//            try {
+//                OpenShiftUtils.getInstance().load(new URL(TEMPLATE_URL).openStream()).createOrReplace();
+//            } catch (IOException e) {
+//                e.printStackTrace();
+//            }
             try {
                 OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.isAPodReady("app", "httpendpoints"));
             } catch (InterruptedException | TimeoutException e) {

--- a/utilities/src/main/java/io/syndesis/qe/templates/IrcTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/IrcTemplate.java
@@ -1,5 +1,11 @@
 package io.syndesis.qe.templates;
 
+import io.syndesis.qe.accounts.Account;
+import io.syndesis.qe.accounts.AccountsDirectory;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -11,11 +17,6 @@ import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
 import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
-import io.syndesis.qe.accounts.Account;
-import io.syndesis.qe.accounts.AccountsDirectory;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
-import io.syndesis.qe.wait.OpenShiftWaitUtils;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -31,7 +32,7 @@ public class IrcTemplate {
                     .withContainerPort(6667)
                     .withProtocol("TCP").build());
 
-            OpenShiftUtils.client().deploymentConfigs().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().deploymentConfigs().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)
@@ -65,7 +66,7 @@ public class IrcTemplate {
                     .withTargetPort(new IntOrString(6667))
                     .build());
 
-            OpenShiftUtils.getInstance().client().services().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().services().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)

--- a/utilities/src/main/java/io/syndesis/qe/templates/KuduRestAPITemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/KuduRestAPITemplate.java
@@ -1,5 +1,15 @@
 package io.syndesis.qe.templates;
 
+import static org.assertj.core.api.Assertions.fail;
+
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+
 import io.fabric8.kubernetes.api.model.ContainerPort;
 import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
 import io.fabric8.kubernetes.api.model.IntOrString;
@@ -7,16 +17,7 @@ import io.fabric8.kubernetes.api.model.ServicePortBuilder;
 import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
 import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteBuilder;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
-import io.syndesis.qe.wait.OpenShiftWaitUtils;
 import lombok.extern.slf4j.Slf4j;
-
-import java.util.LinkedList;
-import java.util.List;
-import java.util.concurrent.TimeoutException;
-
-import static org.assertj.core.api.Assertions.fail;
 
 @Slf4j
 public class KuduRestAPITemplate {
@@ -31,7 +32,7 @@ public class KuduRestAPITemplate {
                     .withContainerPort(8080)
                     .build());
 
-            OpenShiftUtils.client().deploymentConfigs().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().deploymentConfigs().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)
@@ -64,7 +65,7 @@ public class KuduRestAPITemplate {
                     .withTargetPort(new IntOrString(8080))
                     .build());
 
-            OpenShiftUtils.getInstance().client().services().createOrReplaceWithNew()
+            OpenShiftUtils.getInstance().services().createOrReplaceWithNew()
                     .editOrNewMetadata()
                     .withName(APP_NAME)
                     .addToLabels(LABEL_NAME, APP_NAME)
@@ -91,7 +92,7 @@ public class KuduRestAPITemplate {
                     .build();
 
             log.info("Creating route {} with path {}", APP_NAME, "/");
-            OpenShiftUtils.client().routes().createOrReplace(route);
+            OpenShiftUtils.getInstance().routes().createOrReplace(route);
 
             try {
                 OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.areExactlyNPodsReady(LABEL_NAME, APP_NAME, 1), 15 * 60 * 1000L);

--- a/utilities/src/main/java/io/syndesis/qe/templates/KuduTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/KuduTemplate.java
@@ -2,13 +2,13 @@ package io.syndesis.qe.templates;
 
 import static org.assertj.core.api.Assertions.fail;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.concurrent.TimeoutException;
-
 import io.syndesis.qe.utils.OpenShiftUtils;
 import io.syndesis.qe.utils.TestUtils;
 import io.syndesis.qe.wait.OpenShiftWaitUtils;
+
+import java.nio.file.Paths;
+import java.util.concurrent.TimeoutException;
+
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -19,12 +19,13 @@ public class KuduTemplate {
 
     public static void deploy() {
         if (!TestUtils.isDcDeployed(APP_NAME)) {
-
-            try (InputStream is = ClassLoader.getSystemResourceAsStream("templates/syndesis-kudu.yml")) {
-                OpenShiftUtils.client().load(is).createOrReplace();
-            } catch (IOException e) {
-                fail("Template processing failed", e);
-            }
+            //OCP4HACK - openshift-client 4.3.0 isn't supported with OCP4 and can't create/delete templates, following line can be removed later
+            OpenShiftUtils.binary().execute("create", "-f", Paths.get("../utilities/src/main/resources/templates/syndesis-kudu.yml").toAbsolutePath().toString());
+//            try (InputStream is = ClassLoader.getSystemResourceAsStream("templates/syndesis-kudu.yml")) {
+//                OpenShiftUtils.getInstance().load(is).createOrReplace();
+//            } catch (IOException e) {
+//                fail("Template processing failed", e);
+//            }
 
             try {
                 OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.isAPodReady(LABEL_NAME, APP_NAME), 15 * 60 * 1000L);

--- a/utilities/src/main/java/io/syndesis/qe/templates/MysqlTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/MysqlTemplate.java
@@ -1,17 +1,12 @@
 package io.syndesis.qe.templates;
 
-import io.fabric8.kubernetes.api.model.ContainerPort;
-import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
-import io.fabric8.kubernetes.api.model.EnvVar;
-import io.fabric8.kubernetes.api.model.IntOrString;
-import io.fabric8.kubernetes.api.model.ServicePortBuilder;
-import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
+import static org.assertj.core.api.Assertions.fail;
+
 import io.syndesis.qe.accounts.Account;
 import io.syndesis.qe.accounts.AccountsDirectory;
 import io.syndesis.qe.utils.OpenShiftUtils;
 import io.syndesis.qe.utils.TestUtils;
 import io.syndesis.qe.wait.OpenShiftWaitUtils;
-import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -20,7 +15,13 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeoutException;
 
-import static org.assertj.core.api.Assertions.fail;
+import io.fabric8.kubernetes.api.model.ContainerPort;
+import io.fabric8.kubernetes.api.model.ContainerPortBuilder;
+import io.fabric8.kubernetes.api.model.EnvVar;
+import io.fabric8.kubernetes.api.model.IntOrString;
+import io.fabric8.kubernetes.api.model.ServicePortBuilder;
+import io.fabric8.kubernetes.api.model.ServiceSpecBuilder;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class MysqlTemplate {
@@ -45,7 +46,7 @@ public class MysqlTemplate {
         templateParams.add(new EnvVar("MYSQL_PASSWORD", DB_PASSWORD, null));
         templateParams.add(new EnvVar("MYSQL_DATABASE", DB_SCHEMA, null));
 
-        OpenShiftUtils.client().deploymentConfigs().createOrReplaceWithNew()
+        OpenShiftUtils.getInstance().deploymentConfigs().createOrReplaceWithNew()
                 .editOrNewMetadata()
                 .withName(APP_NAME)
                 .addToLabels(LABEL_NAME, APP_NAME)
@@ -79,7 +80,7 @@ public class MysqlTemplate {
                 .withTargetPort(new IntOrString(3306))
                 .build());
 
-        OpenShiftUtils.getInstance().client().services().createOrReplaceWithNew()
+        OpenShiftUtils.getInstance().services().createOrReplaceWithNew()
                 .editOrNewMetadata()
                 .withName(APP_NAME)
                 .addToLabels(LABEL_NAME, APP_NAME)

--- a/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
@@ -2,6 +2,14 @@ package io.syndesis.qe.templates;
 
 import static org.assertj.core.api.Fail.fail;
 
+import io.syndesis.qe.Component;
+import io.syndesis.qe.TestConfiguration;
+import io.syndesis.qe.utils.HTTPResponse;
+import io.syndesis.qe.utils.HttpUtils;
+import io.syndesis.qe.utils.OpenShiftUtils;
+import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.utils.TodoUtils;
+
 import org.apache.commons.codec.binary.Base64;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -17,7 +25,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
-import cz.xtf.openshift.OpenShiftBinaryClient;
 import io.fabric8.kubernetes.api.model.ConfigMap;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
@@ -30,22 +37,16 @@ import io.fabric8.openshift.api.model.ImageStream;
 import io.fabric8.openshift.api.model.ImageStreamList;
 import io.fabric8.openshift.api.model.TagImportPolicy;
 import io.fabric8.openshift.api.model.Template;
-import io.syndesis.qe.Component;
-import io.syndesis.qe.TestConfiguration;
-import io.syndesis.qe.utils.HTTPResponse;
-import io.syndesis.qe.utils.HttpUtils;
-import io.syndesis.qe.utils.OpenShiftUtils;
-import io.syndesis.qe.utils.TestUtils;
-import io.syndesis.qe.utils.TodoUtils;
 import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class SyndesisTemplate {
-    private static final int IMAGE_STREAM_COUNT = (TestConfiguration.useOperator() ? 8 : 7);
+    private static final int IMAGE_STREAM_COUNT = TestConfiguration.useOperator() ? 8 : 7;
+
     public static Template getTemplate() {
         try (InputStream is = new URL(TestConfiguration.syndesisTemplateUrl()).openStream()) {
-            return OpenShiftUtils.client().templates().load(is).get();
+            return OpenShiftUtils.getInstance().templates().load(is).get();
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to read template ", ex);
         }
@@ -54,7 +55,7 @@ public class SyndesisTemplate {
     public static ServiceAccount getSupportSA() {
         // Refresh the support SA URL as it can change during multiple tests executions
         try (InputStream is = new URL(TestConfiguration.syndesisTemplateSA()).openStream()) {
-            return OpenShiftUtils.client().serviceAccounts().load(is).get();
+            return OpenShiftUtils.getInstance().serviceAccounts().load(is).get();
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to read SA ", ex);
         }
@@ -70,19 +71,22 @@ public class SyndesisTemplate {
 
     public static void deployUsingTemplate() {
         log.info("Deploying using template");
-        OpenShiftUtils.getInstance().cleanAndAssert();
+        OpenShiftUtils.getInstance().clean();
+        OpenShiftUtils.getInstance().waiters().isProjectClean().waitFor();
 
         // get & create restricted SA
         OpenShiftUtils.getInstance().createServiceAccount(getSupportSA());
         // get token from SA `oc secrets get-token` && wait until created to prevent 404
         TestUtils.waitForEvent(Optional::isPresent,
-                () -> OpenShiftUtils.getInstance().getSecrets().stream().filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token")).findFirst(),
-                TimeUnit.MINUTES,
-                2,
-                TimeUnit.SECONDS,
-                5);
+            () -> OpenShiftUtils.getInstance().getSecrets().stream().filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token"))
+                .findFirst(),
+            TimeUnit.MINUTES,
+            2,
+            TimeUnit.SECONDS,
+            5);
 
-        Secret secret = OpenShiftUtils.getInstance().getSecrets().stream().filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token")).findFirst().get();
+        Secret secret = OpenShiftUtils.getInstance().getSecrets().stream()
+            .filter(s -> s.getMetadata().getName().startsWith("syndesis-oauth-client-token")).findFirst().get();
         // token is Base64 encoded by default
         String oauthTokenEncoded = secret.getData().get("token");
         byte[] oauthTokenBytes = Base64.decodeBase64(oauthTokenEncoded);
@@ -109,14 +113,15 @@ public class SyndesisTemplate {
         }
 
         //TODO: there's a bug in openshift-client, we need to initialize manually
-        OpenShiftUtils.client().roleBindings().createOrReplaceWithNew()
-                .withNewMetadata()
-                    .withName("syndesis:editors")
-                .endMetadata()
-                .withNewRoleRef().withName("edit").endRoleRef()
-                .addNewSubject().withKind("ServiceAccount").withName(Component.SERVER.getName()).withNamespace(TestConfiguration.openShiftNamespace()).endSubject()
-                .addToUserNames(String.format("system:serviceaccount:%s:%s", TestConfiguration.openShiftNamespace(), Component.SERVER.getName()))
-                .done();
+        OpenShiftUtils.getInstance().roleBindings().createOrReplaceWithNew()
+            .withNewMetadata()
+            .withName("syndesis:editors")
+            .endMetadata()
+            .withNewRoleRef().withName("edit").endRoleRef()
+            .addNewSubject().withKind("ServiceAccount").withName(Component.SERVER.getName()).withNamespace(TestConfiguration.openShiftNamespace())
+            .endSubject()
+            .addToUserNames(String.format("system:serviceaccount:%s:%s", TestConfiguration.openShiftNamespace(), Component.SERVER.getName()))
+            .done();
         patchImageStreams();
         importProdImages();
     }
@@ -128,13 +133,15 @@ public class SyndesisTemplate {
             sb.append("****************************************************\n");
             sb.append("* Operator deployment needs user with admin rights *\n");
             sb.append("****************************************************\n");
-            sb.append("If you are using minishift, you can use \"oc adm policy --as system:admin add-cluster-role-to-user cluster-admin developer\"\n");
+            sb.append(
+                "If you are using minishift, you can use \"oc adm policy --as system:admin add-cluster-role-to-user cluster-admin developer\"\n");
             sb.append("Or use syndesis.config.template.use.operator=false\n");
             log.error(sb.toString());
             throw new RuntimeException(sb.toString());
         }
 
-        OpenShiftUtils.getInstance().cleanAndAssert();
+        OpenShiftUtils.getInstance().clean();
+        OpenShiftUtils.getInstance().waiters().isProjectClean().waitFor();
         deployCrd();
         deployOperator();
         importProdImages();
@@ -142,15 +149,15 @@ public class SyndesisTemplate {
         fixMavenRepos();
         patchImageStreams();
         // Prod template does have broker-amq deployment config defined for some reason, so delete it
-        OpenShiftUtils.client().deploymentConfigs().withName("broker-amq").delete();
+        OpenShiftUtils.getInstance().deploymentConfigs().withName("broker-amq").delete();
         TodoUtils.createDefaultRouteForTodo("todo2", "/");
     }
 
     private static void deployCrd() {
         log.info("Creating custom resource definition from " + TestConfiguration.syndesisOperatorCrdUrl());
         try (InputStream is = new URL(TestConfiguration.syndesisOperatorCrdUrl()).openStream()) {
-            CustomResourceDefinition crd = OpenShiftUtils.client().customResourceDefinitions().load(is).get();
-            OpenShiftUtils.client().customResourceDefinitions().create(crd);
+            CustomResourceDefinition crd = OpenShiftUtils.getInstance().customResourceDefinitions().load(is).get();
+            OpenShiftUtils.getInstance().customResourceDefinitions().create(crd);
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to load CRD", ex);
         } catch (KubernetesClientException kce) {
@@ -162,11 +169,10 @@ public class SyndesisTemplate {
 
     private static void deployOperator() {
         log.info("Deploying operator from " + TestConfiguration.syndesisOperatorUrl());
-        final String output = OpenShiftBinaryClient.getInstance().executeCommandWithReturn(
-                "Unable to process operator resource " + TestConfiguration.syndesisOperatorUrl(),
-                "create",
-                "-n", TestConfiguration.openShiftNamespace(),
-                "-f", TestConfiguration.syndesisOperatorUrl()
+        final String output = OpenShiftUtils.binary().execute(
+            "create",
+            "-n", TestConfiguration.openShiftNamespace(),
+            "-f", TestConfiguration.syndesisOperatorUrl()
         );
         log.debug(output);
 
@@ -174,28 +180,29 @@ public class SyndesisTemplate {
 
         log.info("Waiting for syndesis-operator to be ready");
         OpenShiftUtils.xtf().waiters()
-                .areExactlyNPodsReady(1, "syndesis.io/component", "syndesis-operator")
-                .interval(TimeUnit.SECONDS, 20)
-                .timeout(TimeUnit.MINUTES, 10)
-                .assertEventually();
+            .areExactlyNPodsReady(1, "syndesis.io/component", "syndesis-operator")
+            .interval(TimeUnit.SECONDS, 20)
+            .timeout(TimeUnit.MINUTES, 10)
+            .waitFor();
     }
 
     private static void deploySyndesisViaOperator() {
         log.info("Deploying syndesis resource from " + TestConfiguration.syndesisOperatorTemplateUrl());
         try (InputStream is = new URL(TestConfiguration.syndesisOperatorTemplateUrl()).openStream()) {
-            CustomResourceDefinition crd = OpenShiftUtils.client().customResourceDefinitions().load(is).get();
-            Map<String, Object> integration = (Map)crd.getSpec().getAdditionalProperties().get("integration");
+            CustomResourceDefinition crd = OpenShiftUtils.getInstance().customResourceDefinitions().load(is).get();
+            Map<String, Object> integration = (Map) crd.getSpec().getAdditionalProperties().get("integration");
             integration.put("limit", 5);
             if (TestUtils.isJenkins()) {
                 integration.put("stateCheckInterval", 150);
             }
             crd.getSpec().getAdditionalProperties().put("testSupport", true);
-            crd.getSpec().getAdditionalProperties().put("routeHostname", TestConfiguration.openShiftNamespace() + "." + TestConfiguration.openShiftRouteSuffix());
+            crd.getSpec().getAdditionalProperties()
+                .put("routeHostname", TestConfiguration.openShiftNamespace() + "." + TestConfiguration.openShiftRouteSuffix());
             crd.getSpec().getAdditionalProperties().put("imageStreamNamespace", TestConfiguration.openShiftNamespace());
             OpenShiftUtils.invokeApi(
-                    HttpUtils.Method.POST,
-                    "/apis/syndesis.io/v1alpha1/namespaces/" + TestConfiguration.openShiftNamespace() + "/" + TestConfiguration.customResourcePlural(),
-                    Serialization.jsonMapper().writeValueAsString(crd)
+                HttpUtils.Method.POST,
+                "/apis/syndesis.io/v1alpha1/namespaces/" + TestConfiguration.openShiftNamespace() + "/" + TestConfiguration.customResourcePlural(),
+                Serialization.jsonMapper().writeValueAsString(crd)
             );
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to load operator syndesis template", ex);
@@ -203,12 +210,14 @@ public class SyndesisTemplate {
     }
 
     private static void patchImageStreams() {
-        ImageStreamList isl = OpenShiftUtils.client().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component").list();
+        ImageStreamList isl = OpenShiftUtils.getInstance().imageStreams()
+            .inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component").list();
         final int maxRetries = 120;
         int retries = 0;
         while (isl.getItems().size() < IMAGE_STREAM_COUNT) {
             TestUtils.sleepIgnoreInterrupt(5000L);
-            isl = OpenShiftUtils.client().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component").list();
+            isl = OpenShiftUtils.getInstance().imageStreams().inNamespace(TestConfiguration.openShiftNamespace())
+                .withLabel("syndesis.io/component").list();
             retries++;
             if (retries == maxRetries) {
                 fail("Unable to find image streams after " + maxRetries + " tries.");
@@ -219,7 +228,7 @@ public class SyndesisTemplate {
             if (!is.getSpec().getTags().isEmpty()) {
                 is.getSpec().getTags().get(0).setImportPolicy(new TagImportPolicy(false, false));
             }
-            OpenShiftUtils.client().imageStreams().createOrReplace(is);
+            OpenShiftUtils.getInstance().imageStreams().createOrReplace(is);
         });
     }
 
@@ -231,22 +240,23 @@ public class SyndesisTemplate {
                 if (retries != 0) {
                     TestUtils.sleepIgnoreInterrupt(15000L);
                 }
-                ImageStream is = OpenShiftUtils.client().imageStreams().list().getItems().stream()
-                        .filter(imgStream -> imgStream.getMetadata().getName().contains(imageStreamPartialName)).findFirst().get();
+                ImageStream is = OpenShiftUtils.getInstance().imageStreams().list().getItems().stream()
+                    .filter(imgStream -> imgStream.getMetadata().getName().contains(imageStreamPartialName)).findFirst().get();
                 Map<String, String> metadata = new HashMap<>();
                 metadata.put("name", is.getMetadata().getName());
                 metadata.put("namespace", is.getMetadata().getNamespace());
                 // Sometimes the resource versions do not match, therefore it is needed to refresh the value
                 metadata.put("resourceVersion",
-                        OpenShiftUtils.client().imageStreams().withName(is.getMetadata().getName()).get().getMetadata().getResourceVersion());
+                    OpenShiftUtils.getInstance().imageStreams().withName(is.getMetadata().getName()).get().getMetadata().getResourceVersion());
 
                 log.info("Importing image from imagestream " + is.getMetadata().getName());
                 HTTPResponse r = OpenShiftUtils.invokeApi(
-                        HttpUtils.Method.POST,
-                        String.format("/apis/image.openshift.io/v1/namespaces/%s/imagestreamimports", TestConfiguration.openShiftNamespace()),
-                        ImageStreamImport.getJson(
-                                new ImageStreamImport(is.getApiVersion(), metadata, is.getSpec().getTags().get(0).getFrom().getName(), is.getSpec().getTags().get(0).getName())
-                        )
+                    HttpUtils.Method.POST,
+                    String.format("/apis/image.openshift.io/v1/namespaces/%s/imagestreamimports", TestConfiguration.openShiftNamespace()),
+                    ImageStreamImport.getJson(
+                        new ImageStreamImport(is.getApiVersion(), metadata, is.getSpec().getTags().get(0).getFrom().getName(),
+                            is.getSpec().getTags().get(0).getName())
+                    )
                 );
                 responseCode = r.getCode();
                 if (responseCode != 201 && retries == 2) {
@@ -263,12 +273,13 @@ public class SyndesisTemplate {
             final int maxRetries = 120;
             int retries = 0;
             ImageStreamList isl =
-                    OpenShiftUtils.client().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component")
-                            .list();
+                OpenShiftUtils.getInstance().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component")
+                    .list();
 
             while (isl.getItems().size() < IMAGE_STREAM_COUNT) {
                 TestUtils.sleepIgnoreInterrupt(5000L);
-                isl = OpenShiftUtils.client().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component")
+                isl =
+                    OpenShiftUtils.getInstance().imageStreams().inNamespace(TestConfiguration.openShiftNamespace()).withLabel("syndesis.io/component")
                         .list();
                 retries++;
                 if (retries == maxRetries) {
@@ -297,14 +308,14 @@ public class SyndesisTemplate {
             }
         }
 
-        Optional<ConfigMap> cm = OpenShiftUtils.client().configMaps().list().getItems().stream()
-                .filter(cMap -> cMap.getMetadata().getName().equals("syndesis-server-config")).findFirst();
+        Optional<ConfigMap> cm = OpenShiftUtils.getInstance().configMaps().list().getItems().stream()
+            .filter(cMap -> cMap.getMetadata().getName().equals("syndesis-server-config")).findFirst();
         int retries = 0;
         final int maxRetries = TestUtils.isJenkins() ? 60 : 12;
         while (!cm.isPresent() && retries < maxRetries) {
             TestUtils.sleepIgnoreInterrupt(10000L);
-            cm = OpenShiftUtils.client().configMaps().list().getItems().stream()
-                    .filter(cMap -> cMap.getMetadata().getName().equals("syndesis-server-config")).findFirst();
+            cm = OpenShiftUtils.getInstance().configMaps().list().getItems().stream()
+                .filter(cMap -> cMap.getMetadata().getName().equals("syndesis-server-config")).findFirst();
             if (retries == (maxRetries - 1)) {
                 fail("Unable to find syndesis-server-config configmap after {} tries", maxRetries);
             }
@@ -316,19 +327,20 @@ public class SyndesisTemplate {
         // we should ideally parse the yaml, but this should be good for now
         if (!data.contains("maven:")) {
             String mavenRepos = "\nmaven:\n" +
-                    "  repositories:\n" +
-                    "    01_maven_central: https://repo1.maven.org/maven2\n" +
-                    "    02_redhat_ea_repository: https://maven.repository.redhat.com/ga/\n" +
-                    "    03_jboss_ea: https://repository.jboss.org/\n";
+                "  repositories:\n" +
+                "    01_maven_central: https://repo1.maven.org/maven2\n" +
+                "    02_redhat_ea_repository: https://maven.repository.redhat.com/ga/\n" +
+                "    03_jboss_ea: https://repository.jboss.org/\n";
             data += mavenRepos;
         }
         data = data.replaceAll("https://repo1.maven.org/maven2", replacementRepo);
 
-        OpenShiftUtils.client().configMaps().withName("syndesis-server-config").edit().withData(TestUtils.map("application.yml", data)).done();
+        OpenShiftUtils.getInstance().configMaps().withName("syndesis-server-config").edit().withData(TestUtils.map("application.yml", data)).done();
     }
 
     /**
      * Returns \"key\":\"value\".
+     *
      * @param key key to use
      * @param value value to use
      * @return json
@@ -367,11 +379,14 @@ public class SyndesisTemplate {
                 StringBuilder spec = new StringBuilder("");
                 String obj = om.writeValueAsString(imageStreamImport);
                 json.append(obj.substring(0, obj.length() - 1));
-                // Jackson can't serialize Map that is in the List that is in Map's Object value properly, therefore creating the json snippet manually here
+                // Jackson can't serialize Map that is in the List that is in Map's Object value properly, therefore creating the json snippet
+                // manually here
                 spec.append("\"spec\":{").append(jsonKeyValue("import", "true")).append(",")
-                        .append("\"images\":[{\"from\":{").append(jsonKeyValue("kind", "DockerImage")).append(",").append(jsonKeyValue("name", imageStreamImport.getImage()))
-                        .append("},").append("\"to\":{").append(jsonKeyValue("name", imageStreamImport.getName())).append("},\"importPolicy\":{").append(jsonKeyValue("insecure", "true")).append("},\"referencePolicy\":{")
-                        .append(jsonKeyValue("type", "")).append("}}]},\"status\":{}}");
+                    .append("\"images\":[{\"from\":{").append(jsonKeyValue("kind", "DockerImage")).append(",")
+                    .append(jsonKeyValue("name", imageStreamImport.getImage()))
+                    .append("},").append("\"to\":{").append(jsonKeyValue("name", imageStreamImport.getName())).append("},\"importPolicy\":{")
+                    .append(jsonKeyValue("insecure", "true")).append("},\"referencePolicy\":{")
+                    .append(jsonKeyValue("type", "")).append("}}]},\"status\":{}}");
                 json.append(",").append(spec.toString());
                 return json.toString();
             } catch (JsonProcessingException e) {

--- a/utilities/src/main/java/io/syndesis/qe/utils/JMSUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/JMSUtils.java
@@ -6,7 +6,6 @@ import org.apache.activemq.command.ActiveMQTextMessage;
 import javax.jms.JMSException;
 import javax.jms.Message;
 
-import cz.xtf.jms.JmsClient;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
@@ -20,7 +19,7 @@ public final class JMSUtils {
     }
 
     public static Message getMessage(Destination type, String destinationName, long timeout) {
-        try(JmsClientManager manager = new JmsClientManager("tcp")) {
+        try (JmsClientManager manager = new JmsClientManager("tcp")) {
             return withDestination(manager, type, destinationName).receiveMessage(timeout);
         } catch (Exception e) {
             log.error("Unable to get message from JMS", e);
@@ -36,7 +35,7 @@ public final class JMSUtils {
         }
         String text = null;
         if (m instanceof ActiveMQBytesMessage) {
-            text = new String(((ActiveMQBytesMessage)m).getContent().getData());
+            text = new String(((ActiveMQBytesMessage) m).getContent().getData());
         } else {
             try {
                 text = ((ActiveMQTextMessage) m).getText();
@@ -50,7 +49,7 @@ public final class JMSUtils {
     }
 
     public static void sendMessage(Destination type, String name, String content) {
-        try(JmsClientManager manager = new JmsClientManager("tcp")) {
+        try (JmsClientManager manager = new JmsClientManager("tcp")) {
             withDestination(manager, type, name).sendMessage(content);
         } catch (Exception e) {
             log.error("Unable to send message to queue", e);

--- a/utilities/src/main/java/io/syndesis/qe/utils/JmsClient.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/JmsClient.java
@@ -1,0 +1,415 @@
+package io.syndesis.qe.utils;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Destination;
+import javax.jms.ExceptionListener;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+
+import java.io.Serializable;
+import java.net.SocketException;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * [WIP] refactor of former JMSClient
+ *
+ * @author David Simansky | dsimansk@redhat.com
+ */
+public class JmsClient implements AutoCloseable {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JmsClient.class);
+    private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool();
+
+    private final long RECEIVE_TIMEOUT = 5000L;
+    private ConnectionFactory factory;
+    private Connection liveConnection;
+    private Connection topicConnection;
+    private String destinationName;
+    private boolean isQueue;
+    private boolean isPersistant = false;
+    private boolean isTransacted = false;
+    private boolean isDurable;
+    private boolean keepAlive = false;
+    private long timeToLive = 0;
+    private int retries = 10;
+
+    public JmsClient(ConnectionFactory factory) {
+        this.factory = factory;
+    }
+
+    public JmsClient(Connection connection) {
+        keepAlive = true;
+        this.liveConnection = connection;
+    }
+
+    public JmsClient addQueue(String name) {
+        if (destinationName != null) {
+            throw new IllegalArgumentException("Can't set more than one destination per client");
+        }
+        this.destinationName = name;
+        this.isQueue = true;
+        return this;
+    }
+
+    public JmsClient addTopic(String name) {
+        if (destinationName != null) {
+            throw new IllegalArgumentException("Can't set more than one destination per client");
+        }
+        this.destinationName = name;
+        this.isQueue = false;
+        return this;
+    }
+
+    public JmsClient persistant() {
+        this.isPersistant = true;
+        return this;
+    }
+
+    public JmsClient transacted() {
+        this.isTransacted = true;
+        return this;
+    }
+
+    public JmsClient durable() {
+        this.isDurable = true;
+        return this;
+    }
+
+    public JmsClient setRetries(int setRetries) {
+        this.retries = setRetries;
+        return this;
+    }
+
+    public MessageConsumer createTopicConsumer() throws JMSException {
+        return createTopicConsumer(null);
+    }
+
+    public MessageConsumer createTopicConsumer(String selector) throws JMSException {
+        if (isQueue) {
+            throw new IllegalArgumentException("Only for topic, not queue");
+        }
+        String consumerId = "consumer-" + UUID.randomUUID();
+        topicConnection = startConnection(consumerId);
+        Session session = topicConnection.createSession(isTransacted, Session.AUTO_ACKNOWLEDGE);
+        Topic topic = session.createTopic(destinationName);
+        if (isDurable) {
+            if (selector != null) {
+                return session.createDurableSubscriber(topic, consumerId, selector, true);
+            } else {
+                return session.createDurableSubscriber(topic, consumerId);
+            }
+        } else {
+            if (selector != null) {
+                return session.createConsumer(topic, selector);
+            } else {
+                return session.createConsumer(topic);
+            }
+        }
+    }
+
+    public JmsClient keepAlive() {
+        LOGGER.warn("When keepAlive is used, connection must be closed manually");
+        this.keepAlive = true;
+        return this;
+    }
+
+    public JmsClient timeToLive(long ttl) {
+        this.timeToLive = ttl;
+        return this;
+    }
+
+    public Message createMessage() throws JMSException {
+        return createMessage(null);
+    }
+
+    public Message createMessage(Object messageObject) throws JMSException {
+        Connection connection = null;
+        Message result = null;
+        try {
+            connection = startConnection();
+            Session session = null;
+            try {
+                session = connection.createSession(isTransacted, Session.AUTO_ACKNOWLEDGE);
+                if (messageObject == null) {
+                    result = session.createMessage();
+                } else {
+                    if (messageObject instanceof String) {
+                        result = session.createTextMessage((String) messageObject);
+                    } else {
+                        result = session.createObjectMessage((Serializable) messageObject);
+                    }
+                }
+            } finally {
+                if (session != null) {
+                    session.close();
+                }
+            }
+        } finally {
+            safeCloseConnection(connection);
+        }
+        return result;
+    }
+
+    public void sendMessage() throws JMSException {
+        sendMessage("Hello, world!");
+    }
+
+    public void sendMessage(String messageText) throws JMSException {
+        sendMessage(createMessage(messageText));
+    }
+
+    public void sendMessage(Message message) throws JMSException {
+        Connection connection = null;
+        try {
+            connection = startConnection(); //try to be smarter here and initiate start connection
+            Session session = null;
+            try {
+                session = connection.createSession(isTransacted, Session.AUTO_ACKNOWLEDGE);
+                Destination dest;
+                if (isQueue) {
+                    dest = session.createQueue(destinationName);
+                } else {
+                    dest = session.createTopic(destinationName);
+                }
+                MessageProducer producer = session.createProducer(dest);
+                try {
+
+                    if (isPersistant) {
+                        producer.setDeliveryMode(DeliveryMode.PERSISTENT);
+                    }
+                    if (timeToLive > 0) {
+                        producer.setTimeToLive(timeToLive);
+                    }
+
+                    producer.send(message);
+                } finally {
+                    if (producer != null) {
+                        producer.close();
+                    }
+                }
+            } finally {
+                if (session != null) {
+                    session.close();
+                }
+            }
+        } finally {
+            safeCloseConnection(connection);
+        }
+    }
+
+    public Message receiveMessage() throws JMSException {
+        return receiveMessage(RECEIVE_TIMEOUT, null);
+    }
+
+    public Message receiveMessage(String selector) throws JMSException {
+        return receiveMessage(RECEIVE_TIMEOUT, selector);
+    }
+
+    public Message receiveMessage(long timeout) throws JMSException {
+        return receiveMessage(timeout, null);
+    }
+
+    public Message receiveMessage(long timeout, String selector) throws JMSException {
+        Connection connection = null;
+        Message result = null;
+        try {
+            connection = startConnection(); //try to be smarter here and start stable connection
+            Session session = null;
+            try {
+                session = connection.createSession(isTransacted, Session.AUTO_ACKNOWLEDGE);
+                Destination dest;
+                if (isQueue) {
+                    dest = session.createQueue(destinationName);
+                } else {
+                    dest = session.createTopic(destinationName);
+                }
+                MessageConsumer consumer;
+                if (selector != null) {
+                    consumer = session.createConsumer(dest, selector);
+                } else {
+                    consumer = session.createConsumer(dest);
+                }
+                try {
+                    result = consumer.receive(timeout);
+                } finally {
+                    if (consumer != null) {
+                        consumer.close();
+                    }
+                }
+            } finally {
+                if (session != null) {
+                    session.close();
+                }
+            }
+        } finally {
+            safeCloseConnection(connection);
+        }
+        return result;
+    }
+
+    public static String getTextMessage(Message message) throws JMSException {
+        if (message != null && message instanceof TextMessage) {
+            return ((TextMessage) message).getText();
+        }
+        return null;
+    }
+
+    public void disconnect() {
+        if (keepAlive && liveConnection != null) {
+            safeCloseConnection(liveConnection);
+        }
+        if (topicConnection != null) {
+            safeCloseConnection(topicConnection);
+        }
+    }
+
+    @Override
+    public void close() throws Exception {
+        disconnect();
+    }
+
+    private Connection createConnection() throws JMSException {
+        if (destinationName == null) {
+            throw new IllegalArgumentException("Destination is null, can't send message to nowhere");
+        }
+        Connection connection;
+        //if we don't have liveConnection, try to create fresh from factory
+        if (keepAlive) {
+            if (liveConnection == null) {
+                liveConnection = factory.createConnection();
+            }
+            connection = liveConnection;
+        } else {
+            connection = factory.createConnection();
+        }
+        return connection;
+    }
+
+    private void safeCloseConnection(Connection connection) {
+        try {
+            if (connection != null) {
+                connection.stop();
+                //only close if there isn't liveConnection
+                if (!keepAlive) {
+                    connection.close();
+                }
+            }
+        } catch (JMSException e) {
+            LOGGER.debug("Error while disconnecting", e);
+        }
+    }
+
+    private Connection startConnection() throws JMSException {
+        return startConnection(null);
+    }
+
+    private Connection startConnection(String consumerId) throws JMSException {
+        Connection connection = null;
+        int attempts = retries;
+        while (connection == null && attempts > 0) {
+            try {
+                connection = createConnection();
+                if ((!isQueue && consumerId != null) || keepAlive) {
+                    connection.setExceptionListener(new ReconnectListener());
+                }
+                if (consumerId != null) {
+                    connection.setClientID(consumerId);
+                }
+                Future<?> future = EXECUTOR.submit(new StartConnection(connection));
+                future.get(15, TimeUnit.SECONDS);
+            } catch (InterruptedException ex) {
+                LOGGER.warn("Interrupted while starting connection", ex);
+            } catch (ExecutionException ex) {
+                LOGGER.warn("Error during connection start, reattempt");
+                LOGGER.debug("Exception: ", ex);
+                connection = null;
+                attempts--;
+                try {
+                    Thread.sleep(10 * 1000);
+                } catch (InterruptedException e) {
+                    LOGGER.error("Failed to start connection, {} attempts remaining", attempts, e);
+                }
+            } catch (TimeoutException ex) {
+                attempts--;
+                safeCloseConnection(connection);
+                connection = null;
+                LOGGER.error("Failed to start connection, {} attempts remaining", attempts);
+            } catch (JMSException ex) {
+                if (ex.getCause() instanceof SocketException || ex.getMessage().contains("Connection reset")) {
+                    LOGGER.warn("SocketException during connection start");
+                    LOGGER.debug("Exception: ", ex);
+                    connection = null;
+                    attempts--;
+                    try {
+                        Thread.sleep(10 * 1000);
+                    } catch (InterruptedException e) {
+                        LOGGER.error("Failed to start connection, {} attempts remaining", attempts, e);
+                    }
+                } else {
+                    throw ex;
+                }
+            }
+        }
+        if (connection == null) {
+            throw new JMSException("Unable to start connection, see logs for errors.");
+        }
+        return connection;
+    }
+
+    private static class StartConnection implements Callable<Void> {
+        private final Connection connection;
+
+        public StartConnection(Connection connection) {
+            this.connection = connection;
+        }
+
+        @Override
+        public Void call() throws JMSException {
+            connection.start();
+            return null;
+        }
+    }
+
+    /**
+     * Simple ExceptionListener to help preserve connection
+     */
+    private class ReconnectListener implements ExceptionListener {
+        private int retries = 3;
+
+        @Override
+        public void onException(JMSException e) {
+            LOGGER.debug("ExceptionListener invoked");
+            try {
+                if (retries > 0) {
+                    LOGGER.debug("Attempting to reconnect, retries left {}", retries);
+                    retries--;
+                    if (topicConnection != null && !isQueue) {
+                        topicConnection.start();
+                    } else if (liveConnection != null) {
+                        liveConnection.start();
+                    }
+                } else {
+                    LOGGER.debug("Unable to reconnect", e);
+                }
+            } catch (JMSException ex) {
+                LOGGER.debug("Exception thrown in ExceptionListener reconnect", ex);
+            }
+        }
+    }
+}

--- a/utilities/src/main/java/io/syndesis/qe/utils/JmsClientManager.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/JmsClientManager.java
@@ -3,7 +3,6 @@ package io.syndesis.qe.utils;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionFactory;
 
-import cz.xtf.jms.JmsClient;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import lombok.extern.slf4j.Slf4j;
@@ -23,8 +22,8 @@ public class JmsClientManager implements AutoCloseable {
         initValues(protocol);
     }
 
-    private void initValues(String protocol) {
-        this.protocol = protocol;
+    private void initValues(String setProtocol) {
+        this.protocol = setProtocol;
         switch (protocol) {
             case "tcp":
             case "openwire":
@@ -47,6 +46,7 @@ public class JmsClientManager implements AutoCloseable {
         return this.initClient();
     }
 
+    @Override
     public void close() {
         if (jmsClient != null) {
             jmsClient.disconnect();

--- a/utilities/src/main/java/io/syndesis/qe/utils/ODataUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/ODataUtils.java
@@ -13,12 +13,12 @@ import lombok.extern.slf4j.Slf4j;
 public class ODataUtils {
 
     public static String getOpenshiftRoute() {
-        String host = OpenShiftUtils.client().routes().withName("odata").get().getSpec().getHost();
+        String host = OpenShiftUtils.getInstance().routes().withName("odata").get().getSpec().getHost();
         return "http://" + host + "/TripPin/";
     }
 
     public static String getOpenshiftService() {
-        String clusterIp = OpenShiftUtils.client().services().withName("odata").get().getSpec().getClusterIP();
+        String clusterIp = OpenShiftUtils.getInstance().services().withName("odata").get().getSpec().getClusterIP();
         return "http://" + clusterIp + ":8080/TripPin";
     }
 

--- a/utilities/src/main/java/io/syndesis/qe/utils/PublicApiUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/PublicApiUtils.java
@@ -1,11 +1,9 @@
 package io.syndesis.qe.utils;
 
-import cz.xtf.openshift.OpenShiftBinaryClient;
-import io.fabric8.kubernetes.api.model.ServiceAccount;
-import io.syndesis.qe.TestConfiguration;
-import lombok.extern.slf4j.Slf4j;
-
 import static org.assertj.core.api.Assertions.fail;
+
+import io.fabric8.kubernetes.api.model.ServiceAccount;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class PublicApiUtils {
@@ -20,19 +18,18 @@ public class PublicApiUtils {
      * Method creates service account for Public API and gives them competent role
      */
     public static void createServiceAccount() {
-        ServiceAccount existServiceAccount = OpenShiftUtils.client().serviceAccounts().withName(SERVICE_ACCOUNT_NAME).get();
+        ServiceAccount existServiceAccount = OpenShiftUtils.getInstance().serviceAccounts().withName(SERVICE_ACCOUNT_NAME).get();
 
         if (existServiceAccount == null) {
-            OpenShiftUtils.client().serviceAccounts()
+            OpenShiftUtils.getInstance().serviceAccounts()
                     .createNew()
                     .withNewMetadata()
                     .withName(SERVICE_ACCOUNT_NAME)
                     .endMetadata()
                     .done();
-            OpenShiftUtils.xtf().addRoleToUser("edit", "system:serviceaccount:syndesis:syndesis-cd-client");
+//            OpenShiftUtils.xtf().addRoleToUser("edit", "system:serviceaccount:syndesis:syndesis-cd-client");
         }
-        OpenShiftBinaryClient.getInstance().project(TestConfiguration.openShiftNamespace());
-        publicApiToken = OpenShiftBinaryClient.getInstance().executeCommandWithReturn("", "sa", "get-token", SERVICE_ACCOUNT_NAME);
+        publicApiToken = OpenShiftUtils.binary().execute("sa", "get-token", SERVICE_ACCOUNT_NAME);
     }
 
     public static String getPublicToken() {

--- a/utilities/src/main/java/io/syndesis/qe/utils/TodoUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/TodoUtils.java
@@ -27,6 +27,6 @@ public final class TodoUtils {
                 .endSpec()
                 .build();
         log.info("Creating route {} with path {}", name, path);
-        OpenShiftUtils.client().routes().createOrReplace(route);
+        OpenShiftUtils.getInstance().routes().createOrReplace(route);
     }
 }


### PR DESCRIPTION
- Use own version of openshift-client (4.3.0) and don't rely on version
from xtf
- Needed to change xtf-utils to xtf-core to be able to reuse methods
with newer client
- Hacks for OCP4 because the newest openshift-client is not 100%
compatible with OCP4 yet (grep for OCP4HACK)
- CheckStyle

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

//skip-ci
