### PR TITLE
[Reachability] Close the response body to prevent leaked connections

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -275,7 +275,6 @@ public class TestConfiguration {
         System.setProperty("xtf.openshift.url", properties.getProperty(OPENSHIFT_URL));
         System.setProperty("xtf.openshift.master.username", properties.getProperty(SYNDESIS_UI_USERNAME));
         System.setProperty("xtf.openshift.master.password", properties.getProperty(SYNDESIS_UI_PASSWORD));
-        System.setProperty("xtf.openshift.master.token", properties.getProperty(OPENSHIFT_TOKEN));
         System.setProperty("xtf.openshift.namespace", properties.getProperty(OPENSHIFT_NAMESPACE));
 
         // Set oc version - this version of the client will be used as the binary client

--- a/utilities/src/main/java/io/syndesis/qe/utils/HttpUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/HttpUtils.java
@@ -126,7 +126,9 @@ public final class HttpUtils {
             .url(url)
             .get();
         try {
-            getClient().newCall(requestBuilder.build()).execute();
+            Response r = getClient().newCall(requestBuilder.build()).execute();
+            // Close the body to prevent leaked connections
+            r.body().close();
             return true;
         } catch (Exception e) {
             return false;


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
Solves
```
WARNING: A connection to <openshift> was leaked. Did you forget to close a response body? To see where this was allocated, set the OkHttpClient logger level to FINE: Logger.getLogger(OkHttpClient.class.getName()).setLevel(Level.FINE);
```

//skip-ci
