### PR TITLE
Fixed wrong db.schema name from dballocator

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/utils/TestUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/TestUtils.java
@@ -207,7 +207,7 @@ public final class TestUtils {
                 properties.put("url", sourceMap.get("db.jdbc_url"));
                 properties.put("user", sourceMap.get("db.username"));
                 properties.put("password", sourceMap.get("db.password"));
-                properties.put("schema", sourceMap.get("db.name"));
+                properties.put("schema", sourceMap.get("db.schema"));
                 log.debug("UPDATED ACCOUNT {} PROPERTIES:", account.getService());
                 properties.forEach((key, value) -> log.debug("Key: *{}*, value: *{}*", key, value));
                 break;


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

//test: `@db-connection-crud-2-read-create-oracle12`
