### PR TITLE
Add ability to specify test.properties location

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ syndesis.config.ui.password=developer
 syndesis.config.ui.browser=firefox
 ```
 
+You can also use the `syndesis.config.test.properties` system property to specify a different location of the `test.properties` file, relative to the repo root. This can be useful in case you want to quickly switch between e.g. a local minishift instance and a remote openshift instance.
+
 #### Use correct webdriver version for selected browser
 By default the testsuite will download latest drivers which may not work with older browsers.
 

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -15,6 +15,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class TestConfiguration {
 
+
+    private static final String TEST_PROPERTIES_FILE = "syndesis.config.test.properties";
+
     public static final String OPENSHIFT_URL = "syndesis.config.openshift.url";
     public static final String OPENSHIFT_TOKEN = "syndesis.config.openshift.token";
     public static final String OPENSHIFT_NAMESPACE = "syndesis.config.openshift.namespace";
@@ -70,11 +73,11 @@ public class TestConfiguration {
     private final Properties properties = new Properties();
 
     private TestConfiguration() {
-        // first let's try product properties
+        // first let's try properties in module dir
         copyValues(fromPath("test.properties"), true);
 
-        // then product properties
-        copyValues(fromPath("../test.properties"));
+        // then properties in repo root
+        copyValues(fromPath("../" + System.getProperty(TEST_PROPERTIES_FILE, "test.properties")));
 
         // then system variables
         copyValues(System.getProperties());


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci