### PR TITLE
[UI][fix] - fixed randomly failing 'Validate all credentials' smoke test

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/connections/wizard/phases/ConfigureConnectionSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/connections/wizard/phases/ConfigureConnectionSteps.java
@@ -1,10 +1,7 @@
 package io.syndesis.qe.steps.connections.wizard.phases;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
-import static com.codeborne.selenide.Condition.cssClass;
 import static com.codeborne.selenide.Condition.visible;
-import static com.codeborne.selenide.Selenide.$$;
+import static com.codeborne.selenide.Selenide.$;
 
 import io.syndesis.qe.accounts.Account;
 import io.syndesis.qe.accounts.AccountsDirectory;
@@ -12,7 +9,7 @@ import io.syndesis.qe.fragments.common.form.Form;
 
 import org.openqa.selenium.By;
 
-import com.codeborne.selenide.ElementsCollection;
+import com.codeborne.selenide.SelenideElement;
 
 import java.util.Map;
 import java.util.Optional;
@@ -45,10 +42,9 @@ public class ConfigureConnectionSteps {
     }
 
     private void fillFormInLowerCase(Map<String, String> properties) {
-        ElementsCollection formsCollection = $$(By.tagName("form")).filter(cssClass("pf-c-form"));
-        assertThat(formsCollection).hasSize(1);
+        SelenideElement form = $(By.className("pf-c-form")).waitUntil(visible, 5000);
 
-        new Form(formsCollection.get(0).shouldBe(visible)).fillByTestId(
+        new Form(form.shouldBe(visible)).fillByTestId(
             properties.entrySet().stream()
                 .collect(Collectors.toMap(entry -> entry.getKey().toLowerCase(), Map.Entry::getValue))
         );


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

Sometimes the 'Validate all credentials smoke' test fails in PR job. I noticed in the code that we find all forms in the page, filter the particular form and check when the form is there. Probably the page has not been ready yet when the code was looking for the form.
Does we need to do that way? When we know the particular cssClass name for the form, we can just find it.
