### PR TITLE
Fix different credentials working for email connector

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -59,6 +59,7 @@ import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -611,6 +612,15 @@ public class CommonSteps {
     public void fillFormViaTestID(DataTable data) {
         Form.waitForInputs(20);
         new Form(new SyndesisRootPage().getRootElement()).fillByTestId(data.asMap(String.class, String.class));
+    }
+
+    @Then("^fill in data-testid field \"([^\"]*)\" from property \"([^\"]*)\" of credentials \"([^\"]*)\"")
+    public void fillFormByTestIdFromCreds(String testId, String property, String credentials) {
+        Account account = AccountUtils.get(credentials);
+        Map<String, String> map = new HashMap<>();
+        map.put(testId, account.getProperty(property));
+
+        new Form(new SyndesisRootPage().getRootElement()).fillByTestId(map);
     }
 
     @Then("^force fill in values by element data-testid$")

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/other/GMailSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/other/GMailSteps.java
@@ -1,5 +1,7 @@
 package io.syndesis.qe.steps.other;
 
+import io.syndesis.qe.accounts.Account;
+import io.syndesis.qe.utils.AccountUtils;
 import io.syndesis.qe.utils.GMailUtils;
 import io.syndesis.qe.utils.GoogleAccount;
 import io.syndesis.qe.utils.TestUtils;
@@ -44,6 +46,17 @@ public class GMailSteps {
         sendEmail(sendTo, "syndesis-tests");
     }
 
+    @When("^.*send an e-mail to credentials \"([^\"]*)\"$")
+    public void sendEmailToCreds(String credentials) {
+        sendEmailToCreds(credentials, "syndesis-tests");
+    }
+
+    @When("^.*send an e-mail to credentials \"([^\"]*)\" with subject \"([^\"]*)\"$")
+    public void sendEmailToCreds(String credentials, String subject) {
+        Account account = AccountUtils.get(credentials);
+        sendEmail(account.getProperty("username"), subject);
+    }
+
     @When("^.*send an e-mail to \"([^\"]*)\" with subject \"([^\"]*)\"$")
     public void sendEmail(String sendTo, String subject) {
         gmu.sendEmail("me", sendTo, subject, "Red Hat");
@@ -54,11 +67,25 @@ public class GMailSteps {
         gmu.deleteMessages(from, subject);
     }
 
+    @Given("^delete emails from credentials \"([^\"]*)\" with subject \"([^\"]*)\"$")
+    public void deleteMailsFromCreds(String creds, String subject) {
+        Account account = AccountUtils.get(creds);
+        deleteMails(account.getProperty("username"), subject);
+    }
+
     @Then("^check that email from \"([^\"]*)\" with subject \"([^\"]*)\" and text \"([^\"]*)\" exists$")
     public void checkMails(String from, String subject, String text) {
         TestUtils.waitFor(() -> checkMailExists(from, subject, text),
-            1, 10,
+            1, 60,
             "Could not find specified mail");
+    }
+
+    @Then("^check that email from credenitals \"([^\"]*)\" with subject \"([^\"]*)\" and text \"([^\"]*)\" exists")
+    public void checkMailsFromCredentials(String credentials, String subject, String text) {
+        Account account = AccountUtils.get(credentials);
+        String username = account.getProperty("username");
+
+        checkMails(username, subject, text);
     }
 
     private boolean checkMailExists(String from, String subject, String text) {

--- a/ui-tests/src/test/resources/features/integrations/email.feature
+++ b/ui-tests/src/test/resources/features/integrations/email.feature
@@ -10,7 +10,6 @@ Feature: Email connector
     Given clean application state
     And reset content of "todo" table
     And reset content of "contact" table
-    And delete emails from "jbossqa.fuse.email@gmail.com" with subject "syndesis-tests"
     And log into the Syndesis
     And navigate to the "Home" page
 
@@ -19,6 +18,7 @@ Feature: Email connector
 
     Given created connections
       | Send Email (smtp) | Email SMTP With <security> | Send Email with <security> QE | Send email test |
+    And delete emails from credentials "Email SMTP With <security>" with subject "syndesis-tests"
 
     # Create integration
     When navigate to the "Home" page
@@ -40,8 +40,8 @@ Feature: Email connector
     And select "Send Email" integration action
     And fill in values by element ID
       | to      | jbossqa.fuse@gmail.com       |
-      | from    | jbossqa.fuse.email@gmail.com |
       | subject | syndesis-tests               |
+    And fill in data-testid field "from" from property "username" of credentials "Email SMTP With <security>"
     And click on the "Done" button
     # Then check visibility of page "Add to Integration"
 
@@ -65,8 +65,8 @@ Feature: Email connector
     And publish integration
     Then Integration "email-send-qe-integration" is present in integrations list
     And wait until integration "email-send-qe-integration" gets into "Running" state
-    And check that email from "jbossqa.fuse.email@gmail.com" with subject "syndesis-tests" and text "Red Hat" exists
-    And delete emails from "jbossqa.fuse.email@gmail.com" with subject "syndesis-tests"
+    And check that email from credenitals "Email SMTP With <security>" with subject "syndesis-tests" and text "Red Hat" exists
+    And delete emails from credentials "Email SMTP With <security>" with subject "syndesis-tests"
 
     Examples:
       | security |
@@ -89,8 +89,9 @@ Feature: Email connector
     When select the "Receive Email with <protocol> QE" connection
     Then select "Receive Email" integration action
     And fill in values by element ID
-      | delay      | 30 |
-      | maxresults | 10 |
+      | delay      | 30   |
+      | maxresults | 10   |
+      | unseenonly | true |
     And click on the "Done" button
     Then check that position of connection to fill is "Finish"
 
@@ -119,7 +120,7 @@ Feature: Email connector
     And wait until integration "email-receive-qe-integration" gets into "Running" state
 
     # Send email to connector, wait for it to be received and check that it's content got into database
-    When send an e-mail to "jbossqa.fuse.email@gmail.com"
+    When send an e-mail to credentials "Email <protocol> With SSL"
     Then check that query "select * from todo where task like '%Red Hat%'" has some output
 
     Examples:
@@ -145,6 +146,7 @@ Feature: Email connector
       | delay      | 30     |
       | maxresults | 10     |
       | folder     | folder |
+      | unseenonly | true   |
     And click on the "Done" button
     Then check that position of connection to fill is "Finish"
 
@@ -171,5 +173,5 @@ Feature: Email connector
     And wait until integration "email-receive-qe-integration" gets into "Running" state
 
     # Send email to connector, wait for it to be received and check that it's content got into database
-    When send an e-mail to "jbossqa.fuse.email@gmail.com" with subject "syndesis-tests-folder"
+    When send an e-mail to credentials "Email IMAP With SSL" with subject "syndesis-tests-folder"
     Then check that query "select * from todo where task like '%Red Hat%'" has some output


### PR DESCRIPTION
This removes hardcoded email from email tests and allows change of email credentials

//test: `@email`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
