### PR TITLE
[fix] post existing - affected by ENTESB-11675, and added 2 waits

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/api-provider.feature
+++ b/ui-tests/src/test/resources/features/integrations/api-provider.feature
@@ -206,6 +206,7 @@ Feature: API Provider Integration
 
     And add integration step on position "1"
     And select "Data Mapper" integration step
+    And sleep for 2 seconds
     And open data mapper collection mappings
     And create data mapper mappings
       | id        | body.id        |
@@ -318,7 +319,7 @@ Feature: API Provider Integration
     And validate that all todos with task "task1" have value completed "1", period in ms: "1000"
     And validate that number of all todos with task "task1" is "1"
 
-  
+  @ENTESB-11675
   @api-provider-post-existing
   Scenario: API Provider POST existing
     When create an API Provider integration "TODO Integration post existing" from file swagger/connectors/todo.json

--- a/ui-tests/src/test/resources/features/integrations/sql-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/sql-connector.feature
@@ -109,6 +109,7 @@ Feature: SQL Connector
     # add data mapper
     And add integration step on position "0"
     And select "Data Mapper" integration step
+    And sleep for 2 seconds
     And open data mapper collection mappings
     And create data mapper mappings
       | id | id |


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
 //test: `@api-provider-get-collection or @sql-connector-predicates`

Just annotated one of the tests - it's affected by an yet unhandled error response from DB connector and added 2 waits - to solve issue in api-provider-get-collection and sql-connector-predicates.