### PR TITLE
[FUSEQE-6054] Remove hardcoded gmail address from tests

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/other/GMailSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/other/GMailSteps.java
@@ -38,7 +38,7 @@ public class GMailSteps {
 
     @When("^.*send an e-mail$")
     public void sendMail() {
-        sendEmail("jbossqa.fuse@gmail.com");
+        sendEmail(gmu.getGmailAddress("QE Google Mail"));
     }
 
     @When("^.*send an e-mail to \"([^\"]*)\"$")
@@ -64,18 +64,18 @@ public class GMailSteps {
 
     @Given("^delete emails from \"([^\"]*)\" with subject \"([^\"]*)\"$")
     public void deleteMails(String from, String subject) {
-        gmu.deleteMessages(from, subject);
+        gmu.deleteMessages(gmu.getGmailAddress(from), subject);
     }
 
     @Given("^delete emails from credentials \"([^\"]*)\" with subject \"([^\"]*)\"$")
     public void deleteMailsFromCreds(String creds, String subject) {
         Account account = AccountUtils.get(creds);
-        deleteMails(account.getProperty("username"), subject);
+        gmu.deleteMessages(account.getProperty("username"), subject);
     }
 
     @Then("^check that email from \"([^\"]*)\" with subject \"([^\"]*)\" and text \"([^\"]*)\" exists$")
     public void checkMails(String from, String subject, String text) {
-        TestUtils.waitFor(() -> checkMailExists(from, subject, text),
+        TestUtils.waitFor(() -> checkMailExists(gmu.getGmailAddress(from), subject, text),
             1, 60,
             "Could not find specified mail");
     }
@@ -85,7 +85,9 @@ public class GMailSteps {
         Account account = AccountUtils.get(credentials);
         String username = account.getProperty("username");
 
-        checkMails(username, subject, text);
+        TestUtils.waitFor(() -> checkMailExists(username, subject, text),
+            1, 60,
+            "Could not find specified mail");
     }
 
     private boolean checkMailExists(String from, String subject, String text) {

--- a/ui-tests/src/test/resources/features/connections/oauth.feature
+++ b/ui-tests/src/test/resources/features/connections/oauth.feature
@@ -27,7 +27,7 @@ Feature: Connections - OAuth
 
   @oauth-gmail
   Scenario: Testing Gmail OAuth connector
-    Given delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-tests"
+    Given delete emails from "QE Google Mail" with subject "syndesis-tests"
     When navigate to the "Settings" page
     And fill "Gmail" oauth settings "QE Google Mail"
     And navigate to the "Connections" page
@@ -64,7 +64,7 @@ Feature: Connections - OAuth
 
     When sleep for "6000" ms
     Then validate that logs of integration "OAuth-gmail-test" contains string "syndesis-tests"
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-tests"
+    And delete emails from "QE Google Mail" with subject "syndesis-tests"
 
   @oauth-twitter
   Scenario: Testing Twitter OAuth connector

--- a/ui-tests/src/test/resources/features/integrations/data-buckets.feature
+++ b/ui-tests/src/test/resources/features/integrations/data-buckets.feature
@@ -13,7 +13,7 @@ Feature: Integration - Databucket
   Background: Clean application state
     Given clean application state
     And reset content of "contact" table
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "Red Hat"
+    And delete emails from "QE Google Mail" with subject "Red Hat"
     And log into the Syndesis
     And navigate to the "Settings" page
     And fill all oauth settings
@@ -92,8 +92,7 @@ Feature: Integration - Databucket
 
     When select the "QE Google Mail" connection
     And select "Send Email" integration action
-    And fill in values by element data-testid
-      | to | jbossqa.fuse@gmail.com |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And click on the "Done" button
 
     # add another connection
@@ -127,8 +126,8 @@ Feature: Integration - Databucket
     And publish integration
     Then Integration "Integration_with_buckets" is present in integrations list
     And wait until integration "Integration_with_buckets" gets into "Running" state
-    And check that email from "jbossqa.fuse@gmail.com" with subject "Red Hat" and text "Red Hat" exists
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "Red Hat"
+    And check that email from "QE Google Mail" with subject "Red Hat" and text "Red Hat" exists
+    And delete emails from "QE Google Mail" with subject "Red Hat"
 
 
 #

--- a/ui-tests/src/test/resources/features/integrations/email.feature
+++ b/ui-tests/src/test/resources/features/integrations/email.feature
@@ -38,9 +38,9 @@ Feature: Email connector
     # Second connection is email send (smtp)
     When select the "Send Email with <security> QE" connection
     And select "Send Email" integration action
-    And fill in values by element ID
-      | to      | jbossqa.fuse@gmail.com       |
-      | subject | syndesis-tests               |
+    And fill in values by element data-testid
+      | subject | syndesis-tests |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And fill in data-testid field "from" from property "username" of credentials "Email SMTP With <security>"
     And click on the "Done" button
     # Then check visibility of page "Add to Integration"

--- a/ui-tests/src/test/resources/features/integrations/gmail.feature
+++ b/ui-tests/src/test/resources/features/integrations/gmail.feature
@@ -11,7 +11,7 @@ Feature: Google mail Connector
   Background: Clean application state
     Given clean application state
     And reset content of "contact" table
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-test"
+    And delete emails from "QE Google Mail" with subject "syndesis-test"
     And log into the Syndesis
     And navigate to the "Settings" page
     And fill "Gmail" oauth settings "QE Google Mail"
@@ -41,9 +41,9 @@ Feature: Google mail Connector
 
     When select the "My GMail Connector" connection
     And select "Send Email" integration action
-    And fill in values by element ID
-      | to      | jbossqa.fuse@gmail.com |
+    And fill in values by element data-testid
       | subject | syndesis-test          |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And click on the "Next" button
 
     # add split step
@@ -68,8 +68,8 @@ Feature: Google mail Connector
     Then Integration "Integration_gmail_send" is present in integrations list
     # wait for integration to get in active state
     And wait until integration "Integration_gmail_send" gets into "Running" state
-    And check that email from "jbossqa.fuse@gmail.com" with subject "syndesis-test" and text "Red Hat" exists
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-test"
+    And check that email from "QE Google Mail" with subject "syndesis-test" and text "Red Hat" exists
+    And delete emails from "QE Google Mail" with subject "syndesis-test"
 
 #
 #  2. Receive an e-mail
@@ -119,4 +119,4 @@ Feature: Google mail Connector
     #give gmail time to receive mail
     When send an e-mail
     Then check that query "select * from contact where first_name = 'Prokop' AND last_name = 'Dvere'" has some output
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-tests"
+    And delete emails from "QE Google Mail" with subject "syndesis-tests"

--- a/ui-tests/src/test/resources/features/integrations/template.feature
+++ b/ui-tests/src/test/resources/features/integrations/template.feature
@@ -9,7 +9,7 @@ Feature: Templates
   Background: Clean application state
     Given clean application state
     And log into the Syndesis
-    And delete emails from "jbossqa.fuse@gmail.com" with subject "syndesis-template-test"
+    And delete emails from "QE Google Mail" with subject "syndesis-template-test"
     And navigate to the "Settings" page
     And fill "Gmail" oauth settings "QE Google Mail"
     And create connections using oauth
@@ -34,8 +34,8 @@ Feature: Templates
     When select the "QE Google Mail" connection
     And select "Send Email" integration action
     And fill in values by element data-testid
-      | to      | jbossqa.fuse@gmail.com |
       | subject | syndesis-template-test |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And click on the "Next" button
 
     #adding split step to split the result of Db connection
@@ -83,7 +83,7 @@ Feature: Templates
     # wait for integration to get in active state
     And wait until integration "DB to gmail-template" gets into "Running" state
 
-    Then check that email from "jbossqa.fuse@gmail.com" with subject "syndesis-template-test" and text "Joe Jackson works at Red Hat" exists
+    Then check that email from "QE Google Mail" with subject "syndesis-template-test" and text "Joe Jackson works at Red Hat" exists
 
     Examples:
       | template_type | template_text                                  |
@@ -110,8 +110,8 @@ Feature: Templates
     When select the "QE Google Mail" connection
     And select "Send Email" integration action
     And fill in values by element data-testid
-      | to      | jbossqa.fuse@gmail.com |
       | subject | syndesis-template-test |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And click on the "Done" button
 
     #adding split step to split the result of Db connection
@@ -161,7 +161,7 @@ Feature: Templates
     #wait for integration to get in active state
     And wait until integration "DB to gmail-template" gets into "Running" state
 
-    Then check that email from "jbossqa.fuse@gmail.com" with subject "syndesis-template-test" and text "Joe Jackson works at Red Hat" exists
+    Then check that email from "QE Google Mail" with subject "syndesis-template-test" and text "Joe Jackson works at Red Hat" exists
 
   @gh-6317
   @template-code-editor
@@ -182,8 +182,8 @@ Feature: Templates
     When select the "QE Google Mail" connection
     And select "Send Email" integration action
     And fill in values by element data-testid
-      | to      | jbossqa.fuse@gmail.com |
       | subject | syndesis-template-test |
+    And fill in data-testid field "to" from property "email" of credentials "QE Google Mail"
     And click on the "Done" button
 
     #adding split step to split the result of Db connection

--- a/utilities/src/main/java/io/syndesis/qe/utils/GMailUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/GMailUtils.java
@@ -1,5 +1,9 @@
 package io.syndesis.qe.utils;
 
+import static org.assertj.core.api.Assertions.fail;
+
+import io.syndesis.qe.accounts.Account;
+import io.syndesis.qe.accounts.AccountsDirectory;
 
 import com.google.api.client.repackaged.org.apache.commons.codec.binary.Base64;
 import com.google.api.services.gmail.Gmail;
@@ -7,20 +11,20 @@ import com.google.api.services.gmail.model.ListMessagesResponse;
 import com.google.api.services.gmail.model.Message;
 import com.google.api.services.gmail.model.ModifyMessageRequest;
 
-import lombok.extern.slf4j.Slf4j;
-
 import javax.mail.MessagingException;
 import javax.mail.Session;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Properties;
 
-import static org.assertj.core.api.Assertions.fail;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class GMailUtils {
@@ -34,12 +38,23 @@ public class GMailUtils {
     }
 
     private Gmail getClient() {
-        if(client == null){
+        if (client == null) {
             client = ga.gmail();
         }
         return client;
     }
 
+    public String getGmailAddress(String gmailAccount) {
+        String gmailAddress = null;
+        Optional<Account> account = AccountsDirectory.getInstance().getAccount(gmailAccount);
+        if (account.isPresent()) {
+            gmailAddress = account.get().getProperty("email");
+        } else {
+            fail("Credentials for " + gmailAccount + " were not found.");
+        }
+
+        return gmailAddress;
+    }
 
     /**
      * Create a MimeMessage using the parameters provided.
@@ -210,7 +225,6 @@ public class GMailUtils {
             for (Message m : messages) {
                 trashMessage(m.getId());
             }
-
         } catch (IOException e) {
             fail("Exception was thrown while deleting messages.", e);
         }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

//test: `@oauth-gmail or @data-buckets-usage or @template-code-editor or @db-template-mustache-file-upload or @db-template-send or @gmail-send or @gmail-receive or @email-send`