### PR TITLE
Added annotations for failing tests

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/api-provider.feature
+++ b/ui-tests/src/test/resources/features/integrations/api-provider.feature
@@ -1,4 +1,4 @@
-# @sustainer: asmigala@redhat.com
+# @sustainer: mmuzikar@redhat.com
 
 @ui
 @api-provider
@@ -735,6 +735,7 @@ Feature: API Provider Integration
 
   @gh-5332
   @gh-6099
+  @ENTESB-11787
   @api-provider-openapi-modification
   @api-provider-openapi-edit-implemented
   Scenario: API Provider Edit OpenAPI - edit implemented operation

--- a/ui-tests/src/test/resources/features/integrations/template.feature
+++ b/ui-tests/src/test/resources/features/integrations/template.feature
@@ -164,6 +164,7 @@ Feature: Templates
     Then check that email from "QE Google Mail" with subject "syndesis-template-test" and text "Joe Jackson works at Red Hat" exists
 
   @gh-6317
+  @ENTESB-11393
   @template-code-editor
   Scenario: Verify that the code editor for templates is working correctly
     # create integration


### PR DESCRIPTION
//skip-ci
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
