### PR TITLE
[servicenow] fix select from dropdowns

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/service-now.feature
+++ b/ui-tests/src/test/resources/features/integrations/service-now.feature
@@ -28,10 +28,10 @@ Feature: Integration - ServiceNow-amq/log
 
     When select the "ServiceNow" connection
     And select "Retrieve Record" integration action
-    And fill in values by element ID
+    And select "Incident" from "table" dropdown
+    And fill in values by element data-testid
       | limit | 1                |
       | query | number=QACUSTOM4 |
-      | table | incident         |
 
     And click on the "Next" button
     And sleep for jenkins delay or "10" seconds
@@ -77,8 +77,7 @@ Feature: Integration - ServiceNow-amq/log
 
     When select the "ServiceNow" connection
     And select "Add Record" integration action
-    And fill in values by element data-testid
-      | table | u_qa_create_incident |
+    And select "Qa Create Incident" from "table" dropdown
     Then click on the "Next" button
 
     When add integration step on position "0"


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@integrations-servicenow`