### PR TITLE
[webhook] Fix the webhook regex, to conform to the OCP 4.1. URL format

### DIFF
--- a/ui-tests/src/test/resources/features/customizations/connectors/webhook.feature
+++ b/ui-tests/src/test/resources/features/customizations/connectors/webhook.feature
@@ -89,4 +89,4 @@ Feature: Webhook extension
     And sleep for jenkins delay or "10" seconds
 
     Then check that webhook url for "webhook-test-5575" with token "test-webhook" in UI is same as in routes
-    And verify the displayed webhook URL matches regex ^https://i-.*-syndesis\..*/webhook/.*$
+    And verify the displayed webhook URL matches regex ^https://i-.*-syndesis.*/webhook/.*$


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

//test: `@webhook-ui-url`