### PR TITLE
[FUSEQE-6350] - added delay to the CICD dialog page

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/CiCd/ManageCICDPage.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/CiCd/ManageCICDPage.java
@@ -6,6 +6,7 @@ import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
 
 import io.syndesis.qe.pages.SyndesisPageObject;
+import io.syndesis.qe.utils.TestUtils;
 
 import org.openqa.selenium.By;
 
@@ -33,6 +34,8 @@ public class ManageCICDPage extends SyndesisPageObject {
 
     @Override
     public SelenideElement getRootElement() {
+        // the new tag is displayed with a small delay. The dynamic wait is not possible because the empty list is also a valid
+        TestUtils.sleepIgnoreInterrupt(1000);
         return $(ManageCICDPage.Element.ROOT).shouldBe(visible);
     }
 


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@cicddialog`