### PR TITLE
Add wait for operations to fully load (due to OCP 4.1. failures)

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/apiprovider/wizard/ReviewApiProviderActions.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/apiprovider/wizard/ReviewApiProviderActions.java
@@ -5,6 +5,7 @@ import static com.codeborne.selenide.Selenide.$;
 
 import io.syndesis.qe.logic.common.wizard.WizardPhase;
 import io.syndesis.qe.pages.SyndesisPageObject;
+import io.syndesis.qe.utils.TestUtils;
 
 import org.openqa.selenium.By;
 
@@ -48,6 +49,7 @@ public class ReviewApiProviderActions extends SyndesisPageObject implements Wiza
     }
 
     public int getNumberOfOperations() {
+        TestUtils.waitFor(() -> $(Element.OPERATIONS).is(visible), 1, 10, "No provider operations found");
         String operations = $(Element.OPERATIONS).shouldBe(visible).getText().trim().split(" ")[0];
         return Integer.parseInt(operations);
     }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@api-provider-create-from-spec`