### PR TITLE
Fixed the mapper step error in which collections to be opened cannot be found

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -137,13 +137,19 @@ public class DataMapper extends SyndesisPageObject {
      * This method opens all collection mappings we can find on a data mapper
      */
     public void openDataMapperCollectionElement() {
-        TestUtils.waitFor(() -> $(Element.MAPPER_COLLECTION_ICON).is(visible), 1, 10, "No mapper collections found");
-        $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
-            SelenideElement arrow = e.find(Element.ARROW_POINTING_RIGHT);
-            if (arrow.exists() && arrow.is(visible)) {
-                arrow.click();
-            }
-        });
+        // Give page and elements time to load in slower environment
+        // before pressing mapper collection items
+        boolean mapperCollectionFound = TestUtils.waitForNoFail(() -> $(Element.MAPPER_COLLECTION_ICON).is(visible),
+            1, 3);
+
+        if (mapperCollectionFound) {
+            $$(Element.MAPPER_COLLECTION_ICON).forEach(e -> {
+                SelenideElement arrow = e.find(Element.ARROW_POINTING_RIGHT);
+                if (arrow.exists() && arrow.is(visible)) {
+                    arrow.click();
+                }
+            });
+        }
     }
 
     /**

--- a/utilities/src/main/java/io/syndesis/qe/utils/TestUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/TestUtils.java
@@ -165,6 +165,21 @@ public final class TestUtils {
         }
     }
 
+    /**
+     * Same as {@link #waitFor(BooleanSupplier, int, int, String)}, but does not fail in case of timeout,
+     * instead it has return value that determines whether wait condition ended with success
+     * @return true if condition was satisfied, false otherwise
+     */
+    public static boolean waitForNoFail(BooleanSupplier condition, int checkIntervalInSeconds, int timeoutInSeconds) {
+        try {
+            OpenShiftWaitUtils.waitFor(condition, checkIntervalInSeconds * 1000L, timeoutInSeconds * 1000L);
+        } catch (TimeoutException | InterruptedException e) {
+            return false;
+        }
+
+        return true;
+    }
+
     public static void sleepForJenkinsDelayIfHigher(int delayInSeconds) {
         log.debug("sleeping for " + delayInSeconds + " seconds");
         sleepIgnoreInterrupt(Math.max(TestConfiguration.getJenkinsDelay(), delayInSeconds) * 1000);


### PR DESCRIPTION
This fixes the error in step `And open data mapper collection mappings` which fails in case no collections are present on the mapper.

//test: `@email-receive`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
