### PR TITLE
Fix waiting for server redeployment

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -992,8 +992,6 @@ public class CommonSteps {
 
         try {
             OpenShiftWaitUtils.waitForPodIsReloaded("server");
-            OpenShiftWaitUtils.waitFor(() -> OpenShiftUtils.getPodByPartialName("server").isPresent(), 300 * 1000L);
-            OpenShiftWaitUtils.waitFor(() -> OpenShiftWaitUtils.isPodReady(OpenShiftUtils.getPodByPartialName("server").get()), 60 * 1000 * 10L);
         } catch (InterruptedException | TimeoutException e) {
             fail("Server was not reloaded after deployment config change", e);
         }

--- a/utilities/src/main/java/io/syndesis/qe/wait/OpenShiftWaitUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/wait/OpenShiftWaitUtils.java
@@ -238,7 +238,7 @@ public class OpenShiftWaitUtils {
         log.info("Current pod number: " + currentNr);
         int nextNr = currentNr + 1;
 
-        String podPartialNextName = StringUtils.substringBefore(pod.get().getMetadata().getName(), "-" + nextNr);
+        String podPartialNextName = StringUtils.substringBefore(pod.get().getMetadata().getName(), "-" + currentNr) + "-" + nextNr;
         log.info("Waiting for {} pod is reloaded", podPartialNextName);
         waitFor(() -> isPodPresent(podPartialNextName), 60 * 1000 * 10L);
         waitFor(() -> isPodReady(OpenShiftUtils.getPodByPartialName(podPartialNextName).get()), 60 * 1000 * 10L);


### PR DESCRIPTION
//test: `@3scale or @activity-test`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
