### PR TITLE
Classes are transformed only when selector reporting is enabled

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/CucumberTest.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/CucumberTest.java
@@ -45,7 +45,6 @@ public class CucumberTest extends TestSuiteParent {
 
     @AfterClass
     public static void onTestsEnd() {
-        log.info("Tests ended, generating selector report");
         SelectorSnooper.finish();
     }
 }

--- a/ui-tests/src/test/java/io/syndesis/qe/hooks/SelectorSnooper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/hooks/SelectorSnooper.java
@@ -77,6 +77,7 @@ public class SelectorSnooper {
      */
     public static void finish() {
         if (TestConfiguration.snoopSelectors()) {
+            log.info("Generating selector reports");
             reporter.generateReports();
             log.info("Logging selectors took {} ms from total test run", WebElementSelectorDetector.delta);
         }


### PR DESCRIPTION
//skip-ci
The testsuite logged that it's generating selector reports even if that wasn't true, also I refactored ClassTransformerHook a bit to make it future proof if we want to add any more transformers.