### PR TITLE
[Route] Fix NPE in checkRoute

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
+++ b/utilities/src/main/java/io/syndesis/qe/templates/SyndesisTemplate.java
@@ -91,6 +91,8 @@ public class SyndesisTemplate {
     private static void checkRoute() {
         try {
             OpenShiftWaitUtils.waitFor(() -> OpenShiftUtils.getInstance().routes().withName("syndesis").get() != null, 120000L);
+            OpenShiftWaitUtils.waitFor(() -> OpenShiftUtils.getInstance().routes().withName("syndesis").get()
+                .getStatus().getIngress() != null, 120000L);
         } catch (Exception e) {
             fail("Unable to find syndesis route in 120s");
         }


### PR DESCRIPTION
Fixes occasional NPE when deploying syndesis:

```
[2019-10-25 09:40:32,487] INFO  [io.syndesis.qe.utils.TodoUtils:29] Creating route todo2 with path /
java.lang.NullPointerException
	at io.syndesis.qe.templates.SyndesisTemplate.checkRoute(SyndesisTemplate.java:99)
	at io.syndesis.qe.templates.SyndesisTemplate.deploy(SyndesisTemplate.java:53)
	at io.syndesis.qe.bdd.CommonSteps.deploySyndesis(CommonSteps.java:66)
```

//skip-ci