### PR TITLE
add posibility to send message to other than syndesis-amq broker

### DIFF
--- a/rest-tests/src/test/resources/features/soak-deployment.feature
+++ b/rest-tests/src/test/resources/features/soak-deployment.feature
@@ -126,3 +126,6 @@ Feature: soak deployment
       | true     |
     And create integration with name: "stats-guess"
     And wait for integration with name: "stats-guess" to become active
+
+  Scenario: start load
+    Given send "start" message to "first-number" queue on "amq-stability" broker

--- a/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/CommonSteps.java
@@ -5,10 +5,13 @@ import static org.assertj.core.api.Assertions.fail;
 import io.syndesis.common.model.connection.Connection;
 import io.syndesis.qe.Component;
 import io.syndesis.qe.TestConfiguration;
+import io.syndesis.qe.accounts.Account;
 import io.syndesis.qe.endpoints.ConnectionsEndpoint;
 import io.syndesis.qe.endpoints.TestSupport;
 import io.syndesis.qe.templates.SyndesisTemplate;
+import io.syndesis.qe.utils.AccountUtils;
 import io.syndesis.qe.utils.HttpUtils;
+import io.syndesis.qe.utils.JMSUtils;
 import io.syndesis.qe.utils.OpenShiftUtils;
 import io.syndesis.qe.utils.PublicApiUtils;
 import io.syndesis.qe.utils.RestUtils;
@@ -232,5 +235,14 @@ public class CommonSteps {
     @When("^set up ServiceAccount for Public API$")
     public void setUpServiceAccountForPublicAPI() {
         PublicApiUtils.createServiceAccount();
+    }
+
+    @When("^send \"([^\"]*)\" message to \"([^\"]*)\" queue on \"([^\"]*)\" broker$")
+    public void sendMessageToQueueOnBroker(String message, String queue, String brokerAccount) {
+        Account brokerCredentials = AccountUtils.get(brokerAccount);
+        final String userName = brokerCredentials.getProperty("username");
+        final String password = brokerCredentials.getProperty("password");
+        final String brokerpod = brokerCredentials.getProperty("appname");
+        JMSUtils.sendMessage(brokerpod, "tcp", userName, password, JMSUtils.Destination.QUEUE, queue, message);
     }
 }

--- a/utilities/src/main/java/io/syndesis/qe/utils/JMSUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/JMSUtils.java
@@ -2,6 +2,7 @@ package io.syndesis.qe.utils;
 
 import org.apache.activemq.command.ActiveMQBytesMessage;
 import org.apache.activemq.command.ActiveMQTextMessage;
+import org.apache.qpid.jms.message.JmsTextMessage;
 
 import javax.jms.JMSException;
 import javax.jms.Message;
@@ -14,58 +15,84 @@ public final class JMSUtils {
         QUEUE, TOPIC
     }
 
+    private static final String JMS_APP_NAME = "syndesis-amq";
+    private static final String JMS_USER = "amq";
+    private static final String JMS_PASS = "topSecret";
+    private static final String PROTOCOL = "tcp";
+
+    public static void sendMessage(String appName, String jmsProtocol, String user, String pass, Destination type, String destName, String message) {
+        JmsClientManager.sendMessage(appName, jmsProtocol, user, pass, client -> {
+            withDestination(client, type, destName)
+                .sendMessage(message);
+        });
+    }
+
+    public static void sendMessage(String jmsProtocol, Destination type, String name, String content) {
+        sendMessage(JMS_APP_NAME, jmsProtocol, JMS_USER, JMS_PASS, type, name, content);
+    }
+
+    public static void sendMessage(Destination type, String name, String content) {
+        sendMessage(JMS_APP_NAME, PROTOCOL, JMS_USER, JMS_PASS, type, name, content);
+    }
+
+    public static Message getMessage(String appName, String jmsProtocol, String user, String pass, Destination type, String destinationName,
+        long timeout) {
+        return JmsClientManager.receiveMessage(appName, jmsProtocol, user, pass, client ->
+            withDestination(client, type, destinationName)
+                .receiveMessage(timeout));
+    }
+
     public static Message getMessage(Destination type, String destinationName) {
-        return getMessage(type, destinationName, 60000L);
+        return getMessage(PROTOCOL, type, destinationName, 60000L);
     }
 
     public static Message getMessage(Destination type, String destinationName, long timeout) {
-        try (JmsClientManager manager = new JmsClientManager("tcp")) {
-            return withDestination(manager, type, destinationName).receiveMessage(timeout);
-        } catch (Exception e) {
-            log.error("Unable to get message from JMS", e);
-            e.printStackTrace();
-        }
-        return null;
+        return getMessage(PROTOCOL, type, destinationName, timeout);
     }
 
-    public static String getMessageText(Destination type, String destionationName) {
-        Message m = getMessage(type, destionationName);
+    public static Message getMessage(String jmsProtocol, Destination type, String destinationName, long timeout) {
+        return getMessage(JMS_APP_NAME, jmsProtocol, JMS_USER, JMS_PASS, type, destinationName, timeout);
+    }
+
+    public static String getMessageText(Destination type, String destinationName) {
+        return getMessageText(JMS_APP_NAME, PROTOCOL, JMS_USER, JMS_PASS, type, destinationName);
+    }
+
+    public static String getMessageText(String jmsProtocol, Destination type, String destinationName) {
+        return getMessageText(JMS_APP_NAME, jmsProtocol, JMS_USER, JMS_PASS, type, destinationName);
+    }
+
+    public static String getMessageText(String appName, String jmsProtocol, String user, String pass, Destination type, String destinationName) {
+        Message m = getMessage(appName, jmsProtocol, user, pass, type, destinationName, 60000L);
         if (m == null) {
             return null;
         }
         String text = null;
-        if (m instanceof ActiveMQBytesMessage) {
-            text = new String(((ActiveMQBytesMessage) m).getContent().getData());
-        } else {
-            try {
+        try {
+            if (m instanceof JmsTextMessage) {
+                text = ((JmsTextMessage) m).getText();
+            } else if (m instanceof ActiveMQBytesMessage) {
+                text = new String(((ActiveMQBytesMessage) m).getContent().getData());
+            } else {
                 text = ((ActiveMQTextMessage) m).getText();
-            } catch (JMSException e) {
-                log.error("Unable to get text from message", e);
-                e.printStackTrace();
             }
+        } catch (JMSException e) {
+            log.error("Unable to get text from message", e);
+            e.printStackTrace();
         }
+
         log.debug("Got message: " + text);
         return text;
     }
 
-    public static void sendMessage(Destination type, String name, String content) {
-        try (JmsClientManager manager = new JmsClientManager("tcp")) {
-            withDestination(manager, type, name).sendMessage(content);
-        } catch (Exception e) {
-            log.error("Unable to send message to queue", e);
-            e.printStackTrace();
-        }
-    }
-
     public static void clear(Destination type, String name) {
-        Message m = getMessage(type, name, 5000L);
+        Message m = getMessage(PROTOCOL, type, name, 5000L);
         while (m != null) {
-            m = getMessage(type, name, 5000L);
+            m = getMessage(PROTOCOL, type, name, 5000L);
         }
     }
 
-    private static JmsClient withDestination(JmsClientManager manager, Destination type, String name) {
-        JmsClient c = manager.getClient();
+    private static JmsClient withDestination(JmsClient c, Destination type, String name) {
         if (Destination.QUEUE == type) {
             c.addQueue(name);
         } else {

--- a/utilities/src/main/java/io/syndesis/qe/utils/JmsClientManager.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/JmsClientManager.java
@@ -3,22 +3,34 @@ package io.syndesis.qe.utils;
 import org.apache.activemq.ActiveMQConnectionFactory;
 import org.apache.qpid.jms.JmsConnectionFactory;
 
+import javax.jms.Message;
+
+import java.util.function.Consumer;
+import java.util.function.Function;
+
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.client.LocalPortForward;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-public class JmsClientManager implements AutoCloseable {
+public class JmsClientManager {
     private String jmsUrl;
     private int jmsPort;
-    private String jmsPodName = "syndesis-amq";
-    private String jmsUser = "amq";
-    private String jmsPass = "topSecret";
+    private String jmsAppName;
+    private String jmsUser;
+    private String jmsPass;
     private String protocol;
     private LocalPortForward jmsLocalPortForward = null;
     private JmsClient jmsClient;
 
     public JmsClientManager(String protocol) {
+        initValues(protocol);
+    }
+
+    public JmsClientManager(String jmsAppName, String protocol, String jmsUser, String jmsPass) {
+        this.jmsAppName = jmsAppName;
+        this.jmsUser = jmsUser;
+        this.jmsPass = jmsPass;
         initValues(protocol);
     }
 
@@ -37,17 +49,38 @@ public class JmsClientManager implements AutoCloseable {
         }
     }
 
-    public JmsClient getClient() {
+    public static void sendMessage(String jmsAppName, String protocol, String jmsUser, String jmsPass, Consumer<JmsClient> client) {
+        JmsClientManager manager = new JmsClientManager(jmsAppName, protocol, jmsUser, jmsPass);
+
+        try {
+            JmsClient jmsClient = manager.getClient();
+            client.accept(jmsClient);
+        } finally {
+            manager.close();
+        }
+    }
+
+    public static Message receiveMessage(String jmsAppName, String protocol, String jmsUser, String jmsPass, Function<JmsClient, Message> block) {
+        JmsClientManager manager = new JmsClientManager(jmsAppName, protocol, jmsUser, jmsPass);
+
+        try {
+            JmsClient jmsClient = manager.getClient();
+            return block.apply(jmsClient);
+        } finally {
+            manager.close();
+        }
+    }
+
+    private JmsClient getClient() {
         if (jmsLocalPortForward == null || !jmsLocalPortForward.isAlive()) {
             //can be the same pod twice forwarded to different ports? YES
-            Pod pod = OpenShiftUtils.xtf().getAnyPod("app", jmsPodName);
+            Pod pod = OpenShiftUtils.xtf().getAnyPod("app", jmsAppName);
             jmsLocalPortForward = OpenShiftUtils.portForward(pod, jmsPort, jmsPort);
         }
         return this.initClient();
     }
 
-    @Override
-    public void close() {
+    private void close() {
         if (jmsClient != null) {
             jmsClient.disconnect();
             jmsClient = null;


### PR DESCRIPTION
add autostart of soak scenario
jms client refactor: handle exceptions
jms client refactor: get rid of `autocloseable` and use lambdas we don't need to think about auto closing of jms client when we want to use it outside of `JmsUtils`

 //test: `@amqbroker`
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
