### PR TITLE
[FIX] Fix support page tests

### DIFF
--- a/ui-tests/src/test/resources/features/other/support-page.feature
+++ b/ui-tests/src/test/resources/features/other/support-page.feature
@@ -29,6 +29,7 @@ Feature: Support page
 #
 #  2. download all diagnostic info
 #
+  @ENTESB-12366
   @support-page-download-diagnostic
   Scenario: Export diagnostic of all
     And download diagnostics for all integrations
@@ -38,6 +39,7 @@ Feature: Support page
 #
 #    works OK on local computer, seems to be some unstability issue with jenkins job.
   @oauth
+  @ENTESB-12366
   @support-page-download-specific-diagnostic
   Scenario: Export diagnostic of single integration
     Given remove file "syndesis.zip" if it exists


### PR DESCRIPTION
//test: `@support-page-download-diagnostic or @support-page-download-specific-diagnostic`


<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
