### PR TITLE
[lifecycle] Fix integration with same name test

### DIFF
--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/IntegrationHandler.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/IntegrationHandler.java
@@ -114,11 +114,11 @@ public class IntegrationHandler {
             .build();
 
         log.info("Creating integration {}", integration.getName());
-        Assertions.assertThatExceptionOfType(BadRequestException.class)
+        Assertions.assertThatExceptionOfType(AssertionError.class)
             .isThrownBy(() -> {
                 integrationsEndpoint.create(integration);
             })
-            .withMessageContaining("HTTP 400 Bad Request")
+            .withMessageContaining("Unable to invoke endpoint, see logs")
             .withNoCause();
         log.debug("Flushing used steps");
         steps.flushStepDefinitions();

--- a/rest-tests/src/test/resources/features/integration-lifecycle.feature
+++ b/rest-tests/src/test/resources/features/integration-lifecycle.feature
@@ -5,46 +5,46 @@ Feature: Integration - Lifecycle
   Background: Create sample integration
     Given clean application state
     And clean all builds
-    And create start DB periodic sql invocation action step with query "SELECT * FROM TODO" and period "4000" ms
+    Given create start DB periodic sql invocation action step with query "SELECT * FROM TODO" and period "4000" ms
     And add log step
 
   @integrations-lifecycle
   Scenario: Draft state
-    When create new integration with name: "DB to DB rest test draft" and desiredState: "Unpublished"
-    Then verify there are no s2i builds running for integration: "DB to DB rest test draft"
+    When create new integration with name: "DB to log rest test draft" and desiredState: "Unpublished"
+    Then verify there are no s2i builds running for integration: "DB to log rest test draft"
 
   @integrations-lifecycle
   @integrations-lifecycle-activate
   Scenario: Active state
-    When create new integration with name: "DB to DB rest test activate" and desiredState: "Unpublished"
-    When set integration with name: "DB to DB rest test activate" to desiredState: "Published"
-    Then wait for integration with name: "DB to DB rest test activate" to become active
+    When create new integration with name: "DB to log rest test activate" and desiredState: "Unpublished"
+    When set integration with name: "DB to log rest test activate" to desiredState: "Published"
+    Then wait for integration with name: "DB to log rest test activate" to become active
 
   @integrations-lifecycle
   @integrations-lifecycle-act-deact
   Scenario: Activate-Deactivate switch
-    When create new integration with name: "DB to DB rest test act-deact" and desiredState: "Published"
-    Then wait for integration with name: "DB to DB rest test act-deact" to become active
-    When set integration with name: "DB to DB rest test act-deact" to desiredState: "Unpublished"
-    Then validate integration: "DB to DB rest test act-deact" pod scaled to 0
-    When set integration with name: "DB to DB rest test act-deact" to desiredState: "Published"
-    Then validate integration: "DB to DB rest test act-deact" pod scaled to 1
+    When create new integration with name: "DB to log rest test act-deact" and desiredState: "Published"
+    Then wait for integration with name: "DB to log rest test act-deact" to become active
+    When set integration with name: "DB to log rest test act-deact" to desiredState: "Unpublished"
+    Then validate integration: "DB to log rest test act-deact" pod scaled to 0
+    When set integration with name: "DB to log rest test act-deact" to desiredState: "Published"
+    Then validate integration: "DB to log rest test act-deact" pod scaled to 1
 
   @integrations-lifecycle
   @integrations-lifecycle-try-with-same-name
   Scenario: Create with same name
-    When create new integration with name: "DB to DB rest same name" and desiredState: "Published"
-    Then wait for integration with name: "DB to DB rest same name" to become active
+    When create new integration with name: "DB to log rest same name" and desiredState: "Published"
+    Then wait for integration with name: "DB to log rest same name" to become active
     Given create start DB periodic sql invocation action step with query "SELECT * FROM TODO" and period "4000" ms
     And add log step
-    Then try to create new integration with the same name: "DB to DB rest same name" and state: "Unpublished"
+    Then try to create new integration with the same name: "DB to log rest same name" and state: "Unpublished"
 
   @integrations-lifecycle
   @integrations-lifecycle-long
   Scenario: Activate-Deactivate switch 3 times
-    When create new integration with name: "DB to DB rest test act-deact-long" and desiredState: "Published"
-    Then wait for integration with name: "DB to DB rest test act-deact-long" to become active
-    Then switch Inactive and Active state on integration "DB to DB rest test act-deact-long" for 3 times and check pods up/down
+    When create new integration with name: "DB to log rest test act-deact-long" and desiredState: "Published"
+    Then wait for integration with name: "DB to log rest test act-deact-long" to become active
+    Then switch Inactive and Active state on integration "DB to log rest test act-deact-long" for 3 times and check pods up/down
 
   @ENTESB-12493
   Scenario: Recreate integration with the same name


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@integrations-lifecycle-try-with-same-name`