### PR TITLE
[FIX] Fix Google Calendar tests

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/google-calendar.feature
+++ b/ui-tests/src/test/resources/features/integrations/google-calendar.feature
@@ -28,6 +28,7 @@ Feature: Google Calendar Connector
   # Test Create Event action by creating an event existing in one calendar
   # in another one. This is to bypass setting date/time values in the form
   # which was not clear how to achieve in selenium.
+  @ENTESB-12856
   @google-calendar-copy-event
   Scenario: Test Copy Event
     Given navigate to the "Home" page
@@ -127,6 +128,7 @@ Feature: Google Calendar Connector
   # Partial update not yet possible due to #3814 and #3887. Mitigating by
   # using data mapper with partial mapping of fields, plus mapping constants
   # for the fields that are being actually updated.
+  @ENTESB-12856
   @google-calendar-update-event-coming-in
   Scenario: Test Update event coming in
     Given navigate to the "Home" page


### PR DESCRIPTION
//test: `@google-calendar-copy-event or @google-calendar-update-event-coming-in`

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
