### PR TITLE
[FUSEQE-7784] Add read timeout to unsecure rest client

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/utils/RestUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/RestUtils.java
@@ -37,6 +37,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 
 import io.fabric8.kubernetes.client.LocalPortForward;
 import io.fabric8.openshift.api.model.Route;
@@ -62,7 +63,11 @@ public final class RestUtils {
     }
 
     public static Client getInsecureClient() throws RestClientException {
-        final Client client = ClientBuilder.newClient();
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        clientBuilder.connectTimeout(120, TimeUnit.SECONDS);
+        clientBuilder.readTimeout(120, TimeUnit.SECONDS);
+
+        final Client client = clientBuilder.build();
         client.register(new ErrorLogger());
         return client;
     }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@integrations-db-to-db-oracle12`

Expected result of test: fail after 2 mins timeout due to broken dballocator