### PR TITLE
[fix] annotated db tests and dealt with disabled radiobutton in API client

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/customizations/connectors/wizard/steps/SpecifySecurity.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/customizations/connectors/wizard/steps/SpecifySecurity.java
@@ -85,6 +85,8 @@ public class SpecifySecurity extends SyndesisPageObject implements WizardPhase {
     }
 
     public void selectHttpBasicAuthentication() {
-        $(Input.HTTP_BASIC_AUTHENTICATION).setSelected(true);
+        if ($(Input.HTTP_BASIC_AUTHENTICATION).attr("checked") != null) {
+            $(Input.HTTP_BASIC_AUTHENTICATION).setSelected(true);
+        }
     }
 }

--- a/ui-tests/src/test/resources/features/integrations/db-to-db-with-extension.feature
+++ b/ui-tests/src/test/resources/features/integrations/db-to-db-with-extension.feature
@@ -15,6 +15,7 @@ Feature: Integration - DB to DB with extension
     Given import extensions from syndesis-extensions folder
       | syndesis-extension-log-body |
 
+  @ENTESB-12415
   @tech-extension-create-integration-with-new-tech-extension
   Scenario: Create
     Then inserts into "contact" table

--- a/ui-tests/src/test/resources/features/integrations/db-to-db.feature
+++ b/ui-tests/src/test/resources/features/integrations/db-to-db.feature
@@ -182,6 +182,7 @@ Feature: Integration - DB to DB
 #
 #  4. select - create (via buildin procedure)
 #
+  @ENTESB-12415
   @db-connection-crud-4-read-update-inbuilt
   Scenario: Read and create operations on stored procedure
       # INSERT INTO CONTACT(first_name, last_name, company, lead_source) VALUES('Josef','Stieranka','Istrochem','db');

--- a/ui-tests/src/test/resources/features/integrations/integration-status.feature
+++ b/ui-tests/src/test/resources/features/integrations/integration-status.feature
@@ -9,6 +9,7 @@ Feature: Integration - Status
     Given clean application state
     Given log into the Syndesis
 
+  @ENTESB-12415
   @integration-check-starting-status-on-detail-page
   Scenario: Check starting integration status on detail page
     When navigate to the "Home" page
@@ -30,6 +31,7 @@ Feature: Integration - Status
 
     Then check starting integration status on Integration Detail page
 
+  @ENTESB-12415
   @integration-check-starting-status-on-integration-list
   Scenario: Check starting integration status on integration list
     When navigate to the "Home" page
@@ -53,6 +55,7 @@ Feature: Integration - Status
 
     Then check starting integration ASD status on Integrations page
 
+  @ENTESB-12415
   @integration-check-starting-status-on-home-page
   Scenario: Check starting integration status on home page
     When navigate to the "Home" page

--- a/ui-tests/src/test/resources/features/integrations/salesforce-to-database.feature
+++ b/ui-tests/src/test/resources/features/integrations/salesforce-to-database.feature
@@ -20,6 +20,7 @@ Feature: Integration - Salesforce to DB
       | Salesforce | QE Salesforce |
 
   @integrations-salesforce-to-database-scenario
+  @ENTESB-12415
   Scenario: Create
     When navigate to the "Home" page
     And click on the "Create Integration" link to create a new integration.


### PR DESCRIPTION
//test: `@integrations-api-connector`
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
