### PR TITLE
[fix] - remove security selection

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/amq-to-rest.feature
+++ b/ui-tests/src/test/resources/features/integrations/amq-to-rest.feature
@@ -38,8 +38,6 @@ Feature: Integration - AMQ to REST
     When click on the "Next" link
     Then check visibility of page "Specify Security"
 
-    When set up api connector security
-      | authType | HTTP Basic Authentication |
     And click on the "Next" button
     And fill in values by element data-testid
       | name     | Todo connector |

--- a/ui-tests/src/test/resources/features/integrations/webhook-api-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/webhook-api-connector.feature
@@ -26,8 +26,6 @@ Feature: Integration - Webhook to API connector
     When click on the "Next" link
     Then check visibility of page "Specify Security"
 
-    When set up api connector security
-      | authType | HTTP Basic Authentication |
     And click on the "Next" button
     And fill in values by element data-testid
       | name     | Todo connector |


### PR DESCRIPTION
There is only one connector security type and the item cannot be modified

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@integrations-amq-to-rest or @integrations-webhook-api-connector`