### PR TITLE
[FUSEQE-8028][FUSEQE-8013] - Change default CR and enable Jaeger

### DIFF
--- a/rest-tests/src/test/resources/features/operator-deployment.feature
+++ b/rest-tests/src/test/resources/features/operator-deployment.feature
@@ -7,7 +7,7 @@ Feature: Operator Deployment
   Background:
     Given clean default namespace
       And deploy Syndesis CRD
-    And install cluster resources
+      And install cluster resources
       And grant permissions to user
       And create pull secret
       And deploy Syndesis operator

--- a/rest-tests/src/test/resources/features/operator-deployment.feature
+++ b/rest-tests/src/test/resources/features/operator-deployment.feature
@@ -7,6 +7,7 @@ Feature: Operator Deployment
   Background:
     Given clean default namespace
       And deploy Syndesis CRD
+    And install cluster resources
       And grant permissions to user
       And create pull secret
       And deploy Syndesis operator
@@ -129,8 +130,7 @@ Feature: Operator Deployment
   @operator-addons
   @operator-addons-jaeger
   Scenario: Syndesis Operator - Addons - Jaeger
-    When deploy Jaeger
-      And deploy Syndesis CR from file "spec/addons/jaeger.yml"
+    When deploy Syndesis CR from file "spec/addons/jaeger.yml"
     Then wait for Syndesis to become ready
     When create start DB periodic sql invocation action step with query "SELECT * FROM CONTACT" and period "5000" ms
       And add a split step
@@ -145,8 +145,7 @@ Feature: Operator Deployment
   @operator-addons
   @operator-addons-jaeger
   Scenario: Syndesis Operator - Addons - Jaeger - Sampler
-    When deploy Jaeger
-      And deploy Syndesis CR from file "spec/addons/jaeger.sampler.yml"
+    When deploy Syndesis CR from file "spec/addons/jaeger.sampler.yml"
     Then wait for Syndesis to become ready
     When create start DB periodic sql invocation action step with query "SELECT * FROM CONTACT" and period "5000" ms
       And add a split step

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -46,6 +46,7 @@ import io.syndesis.qe.utils.TestUtils;
 import io.syndesis.qe.wait.OpenShiftWaitUtils;
 
 import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
 import org.openqa.selenium.By;
 import org.openqa.selenium.Dimension;
 import org.openqa.selenium.JavascriptExecutor;
@@ -999,9 +1000,8 @@ public class CommonSteps {
      */
     private void set3scaleEnvVar(String url) {
         Syndesis syndesis = ResourceFactory.get(Syndesis.class);
-        Map cr = syndesis.getDeployedCr();
-        Map features = (Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) ((Map<String, Object>) cr.get("spec")).get("components"))
-            .get("server")).get("features");
+        JSONObject cr = new JSONObject(syndesis.getDeployedCr());
+        JSONObject features = cr.getJSONObject("spec").getJSONObject("components").getJSONObject("server").getJSONObject("features");
 
         if (url != null) {
             features.put("managementUrlFor3scale", url);
@@ -1010,7 +1010,7 @@ public class CommonSteps {
         }
 
         try {
-            syndesis.editCr(cr);
+            syndesis.editCr(cr.toMap());
         } catch (IOException e) {
             fail("There was an error while updating the CR", e);
         }
@@ -1053,23 +1053,23 @@ public class CommonSteps {
     /**
      * Save current time to the singleton class
      */
-    @Then("^save time before request$")
-    public void saveBeforeTime() {
-        calendarUtils.setBeforeRequest(Calendar.getInstance());
+    @Then("^save time before request for integration ([^\"]*)$")
+    public void saveBeforeTime(String integrationName) {
+        calendarUtils.setBeforeRequest(Calendar.getInstance(), integrationName);
         log.info("Time before request was saved: "
-            + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendarUtils.getBeforeRequest().getTime()));
+            + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendarUtils.getLastBeforeRequest().getTime()));
         TestUtils.sleepIgnoreInterrupt(3000); // due to border values
     }
 
     /**
      * Save current time to the singleton class
      */
-    @When("^save time after request$")
-    public void saveAfterTime() {
+    @When("^save time after request for integration ([^\"]*)$")
+    public void saveAfterTime(String integrationName) {
         TestUtils.sleepIgnoreInterrupt(3000); // due to border values
-        calendarUtils.setAfterRequest(Calendar.getInstance());
+        calendarUtils.setAfterRequest(Calendar.getInstance(), integrationName);
         log.info("Time after request was saved: "
-            + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendarUtils.getAfterRequest().getTime()));
+            + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendarUtils.getLastAfterRequest().getTime()));
     }
 
     @When("^clean webdriver download folder$")

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/summary/ActivitySteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/summary/ActivitySteps.java
@@ -162,9 +162,9 @@ public class ActivitySteps {
         middleCalendar.setTime(middle);
 
         /*clear milliseconds because UI last processed label contains only minutes*/
-        Calendar beforeRequest = calendarUtils.getBeforeRequest();
+        Calendar beforeRequest = calendarUtils.getLastBeforeRequest();
         beforeRequest.clear(Calendar.MILLISECOND);
-        Calendar afterRequest = calendarUtils.getAfterRequest();
+        Calendar afterRequest = calendarUtils.getLastAfterRequest();
         afterRequest.clear(Calendar.MILLISECOND);
         afterRequest.add(Calendar.SECOND, accuracy);
 

--- a/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/summary/MetricsSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/integrations/summary/MetricsSteps.java
@@ -66,9 +66,9 @@ public class MetricsSteps {
         processedCalendar.setTime(dateWhenProcessed);
 
         /*clear milliseconds because UI last processed label contains only minutes and seconds*/
-        Calendar beforeRequest = calendarUtils.getBeforeRequest();
+        Calendar beforeRequest = calendarUtils.getLastBeforeRequest();
         beforeRequest.clear(Calendar.MILLISECOND);
-        Calendar afterRequest = calendarUtils.getAfterRequest();
+        Calendar afterRequest = calendarUtils.getLastAfterRequest();
         afterRequest.clear(Calendar.MILLISECOND);
         // 5sec accuracy
         beforeRequest.add(Calendar.SECOND, -5);

--- a/ui-tests/src/test/resources/features/other/integration-activity.feature
+++ b/ui-tests/src/test/resources/features/other/integration-activity.feature
@@ -102,9 +102,9 @@ Feature: Activity
     And click on the "Activity" tab
     Then check that in the activity log are 0 activities
 
-    When save time before request
+    When save time before request for integration activity-test
     And invoke post request to webhook in integration activity-test with token test-webhook and body {"first_name":"John","company":"incorrect company"}
-    And save time after request
+    And save time after request for integration activity-test
     And sleep for "3000" ms
     Then check that in the activity log are 1 activities
     # Test activity
@@ -124,9 +124,9 @@ Feature: Activity
     And check that 3. step in the 1. activity contains No output in the output
 
     # post next request
-    When save time before request
+    When save time before request for integration activity-test
     And invoke post request to webhook in integration activity-test with token test-webhook and body {"first_name":"John","company":"Red Hat still incorrect"}
-    And save time after request
+    And save time after request for integration activity-test
     And sleep for "3000" ms
     Then check that in the activity log are 2 activities
     # Test activity
@@ -150,9 +150,9 @@ Feature: Activity
     And check that 5. step in the 1. activity contains No output in the output
 
     # post next request
-    When save time before request
+    When save time before request for integration activity-test
     And invoke post request to webhook in integration activity-test with token test-webhook and body {"first_name":"John","company":"Red Hat"}
-    And save time after request
+    And save time after request for integration activity-test
     And sleep for "3000" ms
     Then check that in the activity log are 3 activities
     # Test activity
@@ -192,9 +192,9 @@ Feature: Activity
     And select the "activity-test" integration
     And click on the "Activity" tab
 
-    When save time before request
+    When save time before request for integration activity-test
     And invoke post request to webhook in integration activity-test with token test-webhook and body {"first_name":"John","company":"incorrect company"}
-    And save time after request
+    And save time after request for integration activity-test
     And sleep for "3000" ms
     Then check that in the activity log are 4 activities
     And check that 1. activity version contains Version 2
@@ -249,9 +249,9 @@ Feature: Activity
     And click on the "Activity" tab
     Then check that in the activity log are 0 activities
 
-    When save time before request
+    When save time before request for integration activity-error
     And invoke post request which can fail to webhook in integration activity-error with token test-webhook and body {"first_name":"John","company":"Red Hat"}
-    And save time after request
+    And save time after request for integration activity-error
     And sleep for "3000" ms
 
     # Test activity
@@ -321,9 +321,9 @@ Feature: Activity
     And click on the "Activity" tab
     Then check that in the activity log are 0 activities
 
-    When save time before request
+    When save time before request for integration activity-error-data-mapper-before
     And invoke post request which can fail to webhook in integration activity-error-data-mapper-before with token test-webhook and body {"first_name":"John","company":"Red Hat"}
-    And save time after request
+    And save time after request for integration activity-error-data-mapper-before
     And sleep for "3000" ms
     # Test activity
     Then check that in the activity log are 1 activities

--- a/ui-tests/src/test/resources/features/other/integration-metrics.feature
+++ b/ui-tests/src/test/resources/features/other/integration-metrics.feature
@@ -111,10 +111,10 @@ Feature: Metrics
     And check that uptime for metrics-test pod is valid
     And check that startdate for metrics-test pod is valid
 
-    When save time before request
+    When save time before request for integration metrics-test
     And invoke post request to webhook in integration metrics-test with token test-webhook and body {"first_name":"John","company":"incorrect company"}
     And validate that logs of integration "metrics-test" contains string "Body: [[{"first_name":"John","company":"incorrect company"}]]"
-    And save time after request
+    And save time after request for integration metrics-test
     And sleep for "3000" ms
     Then check that number of total error is 0
     And check that last processed date is valid
@@ -124,10 +124,10 @@ Feature: Metrics
     And check that uptime for metrics-test pod is valid
     And check that startdate for metrics-test pod is valid
 
-    When save time before request
+    When save time before request for integration metrics-test
     And invoke post request to webhook in integration metrics-test with token test-webhook and body {"first_name":"John","company":"Red Hat still incorrect"}
     And validate that logs of integration "metrics-test" contains string "Body: [[{"first_name":"John","company":"Red Hat still incorrect"}]]"
-    And save time after request
+    And save time after request for integration metrics-test
     And sleep for "3000" ms
     Then check that number of total error is 0
     And check that last processed date is valid
@@ -137,10 +137,10 @@ Feature: Metrics
     And check that uptime for metrics-test pod is valid
     And check that startdate for metrics-test pod is valid
 
-    When save time before request
+    When save time before request for integration metrics-test
     And invoke post request to webhook in integration metrics-test with token test-webhook and body {"first_name":"John","company":"Red Hat"}
     And validate that logs of integration "metrics-test" contains string "Body: [[{"first_name":"John","company":"Red Hat"}]]"
-    And save time after request
+    And save time after request for integration metrics-test
     And sleep for "3000" ms
     Then check that number of total error is 0
     And check that last processed date is valid
@@ -225,10 +225,10 @@ Feature: Metrics
     And check that uptime for metrics-error pod is valid
     And check that startdate for metrics-error pod is valid
 
-    When save time before request
+    When save time before request for integration metrics-error
     And invoke post request to webhook in integration metrics-error with token test-webhook and body {"first_name":"John","company":"Red Hat"}
     And validate that logs of integration "metrics-error" contains string "Body: [[{"first_name":"John","company":"Red Hat"}]]"
-    And save time after request
+    And save time after request for integration metrics-error
     And sleep for "3000" ms
     Then check that number of total error is 0
     And check that last processed date is valid

--- a/utilities/src/main/java/io/syndesis/qe/Component.java
+++ b/utilities/src/main/java/io/syndesis/qe/Component.java
@@ -60,9 +60,6 @@ public enum Component {
         if (!syndesis.isAddonEnabled(Addon.EXTERNAL_DB)) {
             components.add(DB);
         }
-        if (!syndesis.isAddonEnabled(Addon.TODO)) {
-            components.add(TODO);
-        }
         return components;
     }
 

--- a/utilities/src/main/java/io/syndesis/qe/Component.java
+++ b/utilities/src/main/java/io/syndesis/qe/Component.java
@@ -60,6 +60,9 @@ public enum Component {
         if (!syndesis.isAddonEnabled(Addon.EXTERNAL_DB)) {
             components.add(DB);
         }
+        if (!syndesis.isAddonEnabled(Addon.TODO)) {
+            components.add(TODO);
+        }
         return components;
     }
 

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -414,7 +414,6 @@ public class TestConfiguration {
         if (properties.getProperty(SYNDESIS_RUNTIME) == null) {
             defaultProps.setProperty(SYNDESIS_RUNTIME, "springboot");
         }
-        
         if (properties.getProperty(SYNDESIS_PULL_SECRET_NAME) == null) {
             defaultProps.setProperty(SYNDESIS_PULL_SECRET_NAME, "syndesis-pull-secret");
         }

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -51,6 +51,7 @@ public class TestConfiguration {
     public static final String SYNDESIS_CRD_URL = "syndesis.config.crd.url";
     public static final String SYNDESIS_OPERATOR_IMAGE = "syndesis.config.operator.image";
     public static final String SYNDESIS_CR_URL = "syndesis.config.cr.url";
+
     public static final String SYNDESIS_BUILD_PROPERTIES_URL = "syndesis.config.build.properties.url";
 
     public static final String SYNDESIS_PULL_SECRET = "syndesis.config.pull.secret";
@@ -168,7 +169,12 @@ public class TestConfiguration {
                 }
             } else {
                 //OCP 4.x
-                get().overrideProperty(OPENSHIFT_ROUTE_SUFFIX, prefix + StringUtils.substringBetween(openShiftUrl(), "https://api.", ":6443"));
+                if (openShiftUrl().contains("https://api.crc.testing:6443")) {
+                    //CRC
+                    get().overrideProperty(OPENSHIFT_ROUTE_SUFFIX, "apps-crc.testing");
+                } else {
+                    get().overrideProperty(OPENSHIFT_ROUTE_SUFFIX, prefix + StringUtils.substringBetween(openShiftUrl(), "https://api.", ":6443"));
+                }
             }
         }
         return get().readValue(OPENSHIFT_ROUTE_SUFFIX);
@@ -337,23 +343,23 @@ public class TestConfiguration {
     }
 
     private Properties defaultValues() {
-        final Properties props = new Properties();
+        final Properties defaultProps = new Properties();
 
-        props.setProperty(OPENSHIFT_URL, "");
-        props.setProperty(OPENSHIFT_TOKEN, "");
-        props.setProperty(SYNDESIS_REST_API_PATH, "/api/v1");
-        props.setProperty(SYNDESIS_SERVER_ROUTE, "false");
+        defaultProps.setProperty(OPENSHIFT_URL, "");
+        defaultProps.setProperty(OPENSHIFT_TOKEN, "");
+        defaultProps.setProperty(SYNDESIS_REST_API_PATH, "/api/v1");
+        defaultProps.setProperty(SYNDESIS_SERVER_ROUTE, "false");
 
-        props.setProperty(SYNDESIS_CREDENTIALS_FILE, "../credentials.json");
-        props.setProperty(SYNDESIS_VERSIONS_FILE, "src/test/resources/dependencyVersions.properties");
+        defaultProps.setProperty(SYNDESIS_CREDENTIALS_FILE, "../credentials.json");
+        defaultProps.setProperty(SYNDESIS_VERSIONS_FILE, "src/test/resources/dependencyVersions.properties");
 
-        props.setProperty(SYNDESIS_UI_BROWSER, "chrome");
+        defaultProps.setProperty(SYNDESIS_UI_BROWSER, "chrome");
 
-        props.setProperty(OPENSHIFT_NAMESPACE_CLEANUP, "false");
+        defaultProps.setProperty(OPENSHIFT_NAMESPACE_CLEANUP, "false");
 
         // to keep backward compatibility
-        if (props.getProperty(SYNDESIS_URL_SUFFIX) != null && props.getProperty(OPENSHIFT_ROUTE_SUFFIX) == null) {
-            props.setProperty(OPENSHIFT_ROUTE_SUFFIX, props.getProperty(SYNDESIS_URL_SUFFIX));
+        if (properties.getProperty(SYNDESIS_URL_SUFFIX) != null && properties.getProperty(OPENSHIFT_ROUTE_SUFFIX) == null) {
+            defaultProps.setProperty(OPENSHIFT_ROUTE_SUFFIX, properties.getProperty(SYNDESIS_URL_SUFFIX));
         }
 
         String syndesisVersion;
@@ -367,30 +373,33 @@ public class TestConfiguration {
             }
         }
 
-        if (props.getProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL) == null) {
-            props.setProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL, String
+        if (properties.getProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL) == null) {
+            defaultProps.setProperty(SYNDESIS_PUBLIC_OAUTH_PROXY_URL, String
                 .format("https://raw.githubusercontent.com/syndesisio/syndesis/%s/install/support/syndesis-public-oauth-proxy.yml", syndesisVersion));
         }
 
-        props.setProperty(SYNDESIS_CRD_URL, getClass().getClassLoader().getResource("syndesis-crd.yaml").toString());
+        defaultProps.setProperty(SYNDESIS_CRD_URL, getClass().getClassLoader().getResource("syndesis-crd.yaml").toString());
         String operatorVersion;
         if (this.properties.getProperty(SYNDESIS_INSTALL_VERSION) != null) {
             operatorVersion = this.properties.getProperty(SYNDESIS_INSTALL_VERSION);
         } else {
             operatorVersion = "latest";
         }
-        props.setProperty(SYNDESIS_OPERATOR_IMAGE, "syndesis/syndesis-operator" + ':' + operatorVersion);
-        props.setProperty(SYNDESIS_CR_URL, getClass().getClassLoader().getResource("syndesis-minimal.yaml").toString());
+        defaultProps.setProperty(SYNDESIS_OPERATOR_IMAGE, "syndesis/syndesis-operator" + ':' + operatorVersion);
 
-        props.setProperty(SYNDESIS_CUSTOM_RESOURCE_PLURAL, "syndesises");
+        if (properties.getProperty(SYNDESIS_CR_URL) == null) {
+            defaultProps.setProperty(SYNDESIS_CR_URL, "https://raw.githubusercontent.com/syndesisio/fuse-online-install/master/default-cr.yml");
+        }
+
+        defaultProps.setProperty(SYNDESIS_CUSTOM_RESOURCE_PLURAL, "syndesises");
 
         // When the single user property is set (for the env where the syndesis is already deployed and you are not an admin)
         // Make the user "admin" anyway, as that user is used in all k8s client invocations by default
         if (properties.getProperty(SYNDESIS_SINGLE_USER) != null) {
-            props.setProperty(SYNDESIS_ADMIN_USERNAME, properties.getProperty(SYNDESIS_UI_USERNAME));
+            defaultProps.setProperty(SYNDESIS_ADMIN_USERNAME, properties.getProperty(SYNDESIS_UI_USERNAME));
         }
         if (properties.getProperty(SYNDESIS_SINGLE_USER) != null) {
-            props.setProperty(SYNDESIS_ADMIN_PASSWORD, properties.getProperty(SYNDESIS_UI_PASSWORD));
+            defaultProps.setProperty(SYNDESIS_ADMIN_PASSWORD, properties.getProperty(SYNDESIS_UI_PASSWORD));
         }
 
         // Copy syndesis properties to their xtf counterparts - used by binary oc client
@@ -402,26 +411,27 @@ public class TestConfiguration {
         // Set oc version - this version of the client will be used as the binary client
         System.setProperty("xtf.openshift.version", "4.3");
 
-        if (props.getProperty(SYNDESIS_RUNTIME) == null) {
-            props.setProperty(SYNDESIS_RUNTIME, "springboot");
+        if (properties.getProperty(SYNDESIS_RUNTIME) == null) {
+            defaultProps.setProperty(SYNDESIS_RUNTIME, "springboot");
         }
-        if (props.getProperty(SYNDESIS_PULL_SECRET_NAME) == null) {
-            props.setProperty(SYNDESIS_PULL_SECRET_NAME, "syndesis-pull-secret");
-        }
-
-        props.setProperty(STATE_CHECK_INTERVAL, "" + (TestUtils.isJenkins() ? 150 : 60));
-        if (props.getProperty(SNOOP_SELECTORS) == null) {
-            props.setProperty(SNOOP_SELECTORS, "false");
+        
+        if (properties.getProperty(SYNDESIS_PULL_SECRET_NAME) == null) {
+            defaultProps.setProperty(SYNDESIS_PULL_SECRET_NAME, "syndesis-pull-secret");
         }
 
-        if (props.getProperty(CAMEL_K_VERSION) == null) {
-            props.setProperty(CAMEL_K_VERSION, "0.3.4");
+        defaultProps.setProperty(STATE_CHECK_INTERVAL, "" + (TestUtils.isJenkins() ? 150 : 60));
+        if (properties.getProperty(SNOOP_SELECTORS) == null) {
+            defaultProps.setProperty(SNOOP_SELECTORS, "false");
         }
 
-        if (props.getProperty(JAEGER_VERSION) == null) {
-            props.setProperty(JAEGER_VERSION, "v1.15.1");
+        if (properties.getProperty(CAMEL_K_VERSION) == null) {
+            defaultProps.setProperty(CAMEL_K_VERSION, "0.3.4");
         }
-        return props;
+
+        if (properties.getProperty(JAEGER_VERSION) == null) {
+            defaultProps.setProperty(JAEGER_VERSION, "v1.15.1");
+        }
+        return defaultProps;
     }
 
     public String readValue(final String key) {

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/OperatorValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/OperatorValidationSteps.java
@@ -92,6 +92,11 @@ public class OperatorValidationSteps {
         ResourceFactory.get(Syndesis.class).deployCrd();
     }
 
+    @Given("^install cluster resources$")
+    public void installCluster() {
+        ResourceFactory.get(Syndesis.class).installCluster();
+    }
+
     @Given("^grant permissions to user$")
     public void grantPermissions() {
         Syndesis syndesis = ResourceFactory.get(Syndesis.class);

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/PublicOauthProxy.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/PublicOauthProxy.java
@@ -20,14 +20,6 @@ public class PublicOauthProxy implements Resource {
 
     @Override
     public void deploy() {
-        log.info("Creating cluster-wide resources for Public Api");
-        ResourceFactory.get(Syndesis.class).executeOperatorCommandAndWait(
-            "grant",
-            "--publicApi",
-            "true",
-            "-u",
-            TestConfiguration.syndesisUsername()
-        );
         Map<String, String> properties = new HashMap<String, String>();
         properties.put("routeHostname", PUBLIC_API_PROXY_ROUTE);
         ResourceFactory.get(Syndesis.class).updateAddon(Addon.PUBLIC_API, true, properties);

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -97,6 +97,8 @@ public class Syndesis implements Resource {
         changeRuntime(TestConfiguration.syndesisRuntime());
         checkRoute();
         TodoUtils.createDefaultRouteForTodo("todo2", "/");
+
+        // the syndesis-jaeger doesn't contain "syndesis.io/component" label which is using for finding all components. It is added manually here
         new Thread(() -> {
             try {
                 OpenShiftWaitUtils.waitFor(() -> OpenShiftWaitUtils.isPodReady(

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -90,12 +90,25 @@ public class Syndesis implements Resource {
         createPullSecret();
         deployCrd();
         pullOperatorImage();
+        installCluster();
         grantPermissions();
         deployOperator();
         deploySyndesisViaOperator();
         changeRuntime(TestConfiguration.syndesisRuntime());
         checkRoute();
         TodoUtils.createDefaultRouteForTodo("todo2", "/");
+        new Thread(() -> {
+            try {
+                OpenShiftWaitUtils.waitFor(() -> OpenShiftWaitUtils.isPodReady(
+                    OpenShiftUtils.getAnyPod("app.kubernetes.io/instance", "syndesis-jaeger"))
+                );
+                OpenShiftUtils.getInstance().pods().withName(OpenShiftUtils.getPodByPartialName("syndesis-jaeger").get().getMetadata().getName())
+                    .edit().editMetadata().addToLabels("syndesis.io/component", "syndesis-jaeger").endMetadata().done();
+            } catch (Exception e) {
+                log.warn("Syndesis-jaeger pod never reached ready state! " +
+                    "Ignore when the Syndesis is configured to use external Jaeger instance or old DB activity tracking");
+            }
+        }).start();
     }
 
     @Override
@@ -148,6 +161,12 @@ public class Syndesis implements Resource {
         }
     }
 
+    public void installCluster() {
+        executeOperatorCommandAndWait(
+            "install",
+            "cluster");
+    }
+
     /**
      * Pulls the operator image via docker pull.
      */
@@ -180,8 +199,14 @@ public class Syndesis implements Resource {
 
     public void executeOperatorCommandAndWait(String... param) {
         try {
-            this.executeOperatorCommand(param).waitFor();
-        } catch (InterruptedException e) {
+            Process process = this.executeOperatorCommand(param);
+            process.waitFor();
+            if (process.exitValue() != 0) {
+                fail("The docker operator command fail. The exit value is " + process.exitValue() +
+                    "\nThe process error stream: " + IOUtils.toString(process.getErrorStream(), StandardCharsets.UTF_8) +
+                    "\nThe process input stream: " + IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8));
+            }
+        } catch (InterruptedException | IOException e) {
             log.error("Something interrupted the docker command", e);
             fail("Something interrupted the docker command");
         }
@@ -468,7 +493,7 @@ public class Syndesis implements Resource {
                 serverFeatures.put("integrationStateCheckInterval", TestConfiguration.stateCheckInterval());
             }
             serverFeatures.put("integrationLimit", 5);
-
+            crJson.getJSONObject("spec").getJSONObject("addons").getJSONObject("todo").put("enabled", true);
             // add nexus
             addMavenRepo(serverFeatures);
 

--- a/utilities/src/main/java/io/syndesis/qe/utils/CalendarUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/CalendarUtils.java
@@ -1,5 +1,7 @@
 package io.syndesis.qe.utils;
 
+import static org.assertj.core.api.Java6Assertions.fail;
+
 import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
@@ -22,47 +24,49 @@ import lombok.extern.slf4j.Slf4j;
 @Lazy
 public class CalendarUtils {
 
-    /*-2 means that OCP is 2 seconds behind of the instance where the test is running
-      +2 means that OCP is 2 seconds ahead of the instance where the test is running */
-    private int diffSeconds = 0;
-    private int diffMinutes = 0;
-    private int diffHours = 0;
-
-    public CalendarUtils() throws ParseException {
-        Optional<Pod> podByPartialName = OpenShiftUtils.getPodByPartialName("syndesis-server");
-        String ocpTime = OpenShiftUtils.binary().execute(
-            "exec", podByPartialName.get().getMetadata().getName(), "date");
-        Date testDate = new Date();
-        Date ocpDate = new SimpleDateFormat("EEE MMM d hh:mm:ss zzz yyyy").parse(ocpTime);
-        int diff = Math.toIntExact(ocpDate.getTime() - testDate.getTime());
-        diffSeconds = diff / 1000 % 60;
-        diffMinutes = diff / (60 * 1000) % 60;
-        diffHours = diff / (60 * 60 * 1000);
-    }
+    @Getter
+    private Calendar lastBeforeRequest = null;
 
     @Getter
-    private Calendar beforeRequest = null;
+    private Calendar lastAfterRequest = null;
 
-    @Getter
-    private Calendar afterRequest = null;
-
-    public void setBeforeRequest(Calendar beforeRequest) {
-        syncTimeWithOcpInstance(beforeRequest);
-        this.beforeRequest = beforeRequest;
+    public void setBeforeRequest(Calendar beforeRequest, String partialPodName) {
+        syncTimeWithOcpInstance(beforeRequest, partialPodName);
+        this.lastBeforeRequest = beforeRequest;
     }
 
-    public void setAfterRequest(Calendar afterRequest) {
-        syncTimeWithOcpInstance(afterRequest);
-        this.afterRequest = afterRequest;
+    public void setAfterRequest(Calendar afterRequest, String partialPodName) {
+        syncTimeWithOcpInstance(afterRequest, partialPodName);
+        this.lastAfterRequest = afterRequest;
     }
 
     //correct time, sync with the OCP time
-    private void syncTimeWithOcpInstance(Calendar calendar) {
-        log.info("Time before sync: " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendar.getTime()));
+    private void syncTimeWithOcpInstance(Calendar calendar, String partialPodName) {
+        Optional<Pod> podByPartialName = OpenShiftUtils.getPodByPartialName(partialPodName);
+        if (!podByPartialName.isPresent()) {
+            fail("Integration with the partial pod name '" + partialPodName + "' does not exist.");
+        }
+        String integrationTime = OpenShiftUtils.binary().execute(
+            "exec", podByPartialName.get().getMetadata().getName(), "date");
+        Date testDate = new Date();
+        Date ocpDate = null;
+        log.info("Time in the integration pod is: " + integrationTime);
+        log.info("Time in test suite is: " + testDate);
+        try {
+            ocpDate = new SimpleDateFormat("EEE MMM d hh:mm:ss zzz yyyy").parse(integrationTime);
+        } catch (ParseException e) {
+            fail("Exception during parsing the date from the integration pod", e);
+        }
+        int diff = Math.toIntExact(ocpDate.getTime() - testDate.getTime());
+
+        int diffSeconds = diff / 1000 % 60;
+        int diffMinutes = diff / (60 * 1000) % 60;
+        int diffHours = diff / (60 * 60 * 1000);
+
         log.info(String.format("Sync info: HOUR:'%s' MINUTE:'%s' SECOND:'%s'", diffHours, diffMinutes, diffSeconds));
         calendar.add(Calendar.SECOND, diffSeconds);
         calendar.add(Calendar.MINUTE, diffMinutes);
         calendar.add(Calendar.HOUR, diffHours);
-        log.info("Time after sync: " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendar.getTime()));
+        log.info("Test suite time after sync: " + new SimpleDateFormat("yyyy-MM-dd HH:mm:ss").format(calendar.getTime()));
     }
 }

--- a/utilities/src/main/java/io/syndesis/qe/utils/CalendarUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/CalendarUtils.java
@@ -7,7 +7,9 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Date;
+import java.util.Optional;
 
+import io.fabric8.kubernetes.api.model.Pod;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -27,12 +29,11 @@ public class CalendarUtils {
     private int diffHours = 0;
 
     public CalendarUtils() throws ParseException {
+        Optional<Pod> podByPartialName = OpenShiftUtils.getPodByPartialName("syndesis-server");
         String ocpTime = OpenShiftUtils.binary().execute(
-            "run", "--serviceaccount", "builder", "--image", "okansahiner/kube-diag",
-            "kube-diag", "-it", "--restart=Never", "--attach", "--rm", "--command", "--", "bash", "-c", "\"date\"");
-
-        Date ocpDate = new SimpleDateFormat("EEE MMM d hh:mm:ss zzz yyyy").parse(ocpTime);
+            "exec", podByPartialName.get().getMetadata().getName(), "date");
         Date testDate = new Date();
+        Date ocpDate = new SimpleDateFormat("EEE MMM d hh:mm:ss zzz yyyy").parse(ocpTime);
         int diff = Math.toIntExact(ocpDate.getTime() - testDate.getTime());
         diffSeconds = diff / 1000 % 60;
         diffMinutes = diff / (60 * 1000) % 60;


### PR DESCRIPTION
* now, the default-cr.yaml from the fuse online install is used as default CR
* when the docker operator command fails, the whole test suite fail
* Jaeger is used as default activity logging
* add support for generating suffix in the CRC

The test suite will use the `default-cr` from here https://github.com/syndesisio/fuse-online-install/blob/master/default-cr.yml instead of minimal CR from the test suite resources. In case you want to use the one from the resources or `default-cr` from the different branch as master (in the future), you can specify it via `syndesis.config.cr.url`
```
# file from the resources
syndesis.config.cr.url=https://raw.githubusercontent.com/syndesisio/syndesis-qe/master/utilities/src/main/resources/syndesis-minimal.yaml

# different version
syndesis.config.cr.url=https://raw.githubusercontent.com/syndesisio/fuse-online-install/1.9.x/default-cr.yml
```

Contains also fix for the FUSEQE-8013. The time is getting directly from the particular integration.

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

//test: `@activity or @cicddialog or @metrics`
