### PR TITLE
[FIX] Fix @settings-oauth-remove-immediately

### DIFF
--- a/ui-tests/src/test/resources/features/connections/oauth.feature
+++ b/ui-tests/src/test/resources/features/connections/oauth.feature
@@ -104,7 +104,6 @@ Feature: Connections - OAuth
 
   @ENTESB-11282
   @oauth-gcalendar
-  @disabled
   Scenario: Testing Google calendar OAuth connector
     Given renew access token for "QE Google Calendar" google account
     And create calendars
@@ -231,6 +230,7 @@ Feature: Connections - OAuth
 
   @reproducer
   @ENTESB-11447
+  @twitter-oauth-error-msg
   Scenario: Testing Twitter OAuth error message
     When navigate to the "Settings" page
     And click on element with data-testid "o-auth-app-list-item-twitter-list-item"
@@ -246,6 +246,7 @@ Feature: Connections - OAuth
 
   @reproducer
   @ENTESB-12005
+  @oauth-description
   Scenario: Testing oauth description
     When navigate to the "Settings" page
     And fill "Twitter" oauth settings "Twitter Listener"

--- a/ui-tests/src/test/resources/features/other/settings-oauth.feature
+++ b/ui-tests/src/test/resources/features/other/settings-oauth.feature
@@ -31,6 +31,8 @@ Feature: Settings OAuth
 #    And check button "Remove" of item "Google Calendar"
     When click button "Remove" of item "Google Calendar"
     And confirm settings removal
+#    this delay is necessary due to different net delays, to stabilize test
+    And sleep for "3000" ms
   #  Then check visibility of "Delete Successful Settings successfully deleted." in alert-success notification
     And check that given "Google Calendar" oauth settings are not filled in
 


### PR DESCRIPTION
//test: `@settings-oauth-remove-immediately`

explanation: this test fails randomly, because of different network delays. lump time delay should be helpful.

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
