### PR TITLE
[fix] Increase timer default time - to achieve more stable results

### DIFF
--- a/rest-tests/src/test/resources/features/timer-connector.feature
+++ b/rest-tests/src/test/resources/features/timer-connector.feature
@@ -17,13 +17,13 @@ Feature: Integration - Timer
     And sleep for jenkins delay or "10" seconds
     When add "timer" endpoint with connector id "timer" and "timer-action" action and with properties:
       | action       | period |
-      | timer-action | 1000   |
+      | timer-action | 7000   |
 
     And create HTTP "GET" step
     And create integration with name: "timer-to-http-1"
     And wait for integration with name: "timer-to-http-1" to become active
 
-    Then verify that after "2.5" seconds there were "2" calls
+    Then verify that after "8" seconds there were "1" calls
 
   @cron-timer
   Scenario: Cron Timer to GET


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@simple-timer`