### PR TITLE
[FUSEQE-8506] changed prod test to actually test for the exact value

### DIFF
--- a/rest-tests/src/test/resources/features/check-prod-versions.feature
+++ b/rest-tests/src/test/resources/features/check-prod-versions.feature
@@ -8,10 +8,11 @@ Feature: Check productized build
   Background: Create sample integration
     Given clean application state
 
+  @check-prod-version
   Scenario: Check artifacts in integration
     When create start DB periodic sql invocation action step with query "SELECT * FROM CONTACT" and period "5000" ms
-      And add log step
-      And create integration with name: "prod-check"
+    And add log step
+    And create integration with name: "prod-check"
     Then wait for integration with name: "prod-check" to become active
-      And check that integration pom contains productized version in property "syndesis.version"
-      And check that integration pom contains productized version in property "camel.version"
+    And check that integration pom contains productized version in property "syndesis.version"
+    And check that integration pom contains productized version in property "camel.version"

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -92,6 +92,7 @@ public class TestConfiguration {
     private static final String SYNDESIS_RUNTIME = "syndesis.config.runtime";
 
     private static final String JAEGER_VERSION = "syndesis.jaeger.version";
+    private static final String CAMEL_VERSION = "camel.version";
 
     private static final TestConfiguration INSTANCE = new TestConfiguration();
 

--- a/utilities/src/main/java/io/syndesis/qe/bdd/validation/ProdValidationSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/bdd/validation/ProdValidationSteps.java
@@ -57,7 +57,7 @@ public class ProdValidationSteps {
         final XPath xPath = XPathFactory.newInstance().newXPath();
         try {
             assertThat(((Node) xPath.compile("//project/properties/" + property).evaluate(pom, XPathConstants.NODE)).getTextContent())
-                .contains("redhat");
+                .isEqualTo(TestConfiguration.get().readValue(property));
         } catch (XPathExpressionException e) {
             fail("Unable to compile xpath expression: ", e);
         }


### PR DESCRIPTION
//skip-ci
Expects `camel.version` and `syndesis.version` are configured.
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
