### PR TITLE
[FIX] Fix of @oauth-gcalendar test

### DIFF
--- a/ui-tests/src/test/resources/features/connections/oauth.feature
+++ b/ui-tests/src/test/resources/features/connections/oauth.feature
@@ -103,6 +103,7 @@ Feature: Connections - OAuth
     And clean all tweets in twitter_talky account
 
   @ENTESB-11282
+  @ENTESB-13204
   @oauth-gcalendar
   Scenario: Testing Google calendar OAuth connector
     Given renew access token for "QE Google Calendar" google account


### PR DESCRIPTION
//skip-ci
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
