### PR TITLE
Log connector fixes

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/integration-import-export.feature
+++ b/ui-tests/src/test/resources/features/integrations/integration-import-export.feature
@@ -239,5 +239,5 @@ Feature: Integration - Import Export
     Then Integration "Integration_import_export_test" is present in integrations list
     # wait for integration to get in active state
     And wait until integration "Integration_import_export_test" gets into "Running" state
-    Then validate that logs of integration "Integration_import_export_test" contains string ""status":"done","failed":false"
+    Then validate that logs of integration "Integration_import_export_test" contains string "Started Application in"
     And check that last slack message equals "RHEL" on channel "import_export_test"

--- a/ui-tests/src/test/resources/features/integrations/log-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/log-connector.feature
@@ -53,11 +53,11 @@ Feature: Log Connector
     And validate that logs of integration "Integration_with_log_context_<context>_body_<body>" doesn't contain string "<log_not_contains>"
 
     Examples:
-      | context | body | log_contains                    | log_not_contains              |
-      | true    | true | Body: [[{"last_name":"Jackson", | "status":"done","failed":true |
+      | context | body  | log_contains                    | log_not_contains              |
+      | true    | true  | Body: [[{"last_name":"Jackson", | "status":"done","failed":true |
       | false   | true  | Body: [[{"last_name":"Jackson", | Message Context:              |
       | true    | false | Message Context:                | Body: []                      |
-      | false   | false | "status":"done","failed":false  | Message Context:              |
+      | false   | false |                                 | Message Context:              |
 
 #
 #  2. Check that log step works without any message or checkboxes


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@integration-import-from-different-instance or @log-connector-error-message`