### PR TITLE
[FUSEQE-8797] Fix @oauth-gcalendar test

### DIFF
--- a/ui-tests/src/test/resources/features/connections/oauth.feature
+++ b/ui-tests/src/test/resources/features/connections/oauth.feature
@@ -123,7 +123,7 @@ Feature: Connections - OAuth
     Then check that position of connection to fill is "Start"
     When select the "Gcalendar-test" connection
     And select "Get Events" integration action
-    And fill in values by element data-testid
+    And fill in aliased calendar values by data-testid
       | consumefromnow     | false          |
       | considerlastupdate | false          |
       | calendarid         | syndesis-test1 |


### PR DESCRIPTION
backport to master
//test: `@oauth-gcalendar`
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
