### PR TITLE
[FUSEQE-8681][pf4-migration] fix @create-delete-api-connector

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/customizations/connectors/ApiClientConnectors.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/customizations/connectors/ApiClientConnectors.java
@@ -20,7 +20,7 @@ public class ApiClientConnectors extends SyndesisPageObject {
     private static final class Element {
         public static final By ROOT = ByUtils.dataTestId("api-connector-list");
         public static By CONNECTOR_TITLE = ByUtils.dataTestId("api-connector-name");
-        public static By CONNECTORS_LIST_ITEM = ByUtils.containsDataTestId("api-connector-list-item");
+        public static By CONNECTORS_LIST_ITEM = ByUtils.containsDataTestId("li", "api-connector-list-item");
         public static By DETAIL_BUTTON = ByUtils.dataTestId("a", "api-connector-list-item-details-button");
     }
 

--- a/ui-tests/src/test/resources/features/customizations/connectors/api-client-connector-CRUD.feature
+++ b/ui-tests/src/test/resources/features/customizations/connectors/api-client-connector-CRUD.feature
@@ -80,6 +80,7 @@ Feature: Customization - API Connector CRUD
       | host        | http://petstore.swagger.io-1 |
       | basepath    | /v2-1                        |
 
+  @ENTESB-13605
   @create-delete-api-connector
   Scenario: Delete
     When click on the "Customizations" link


### PR DESCRIPTION
//skip-ci
Changed the selector to find only the list items, the test still fails though because of ENTESB-13605
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
