### PR TITLE
[FUSEQE-8681] - prevent form to use stale elements

### DIFF
--- a/rest-tests/src/test/resources/features/publicapi/connections.feature
+++ b/rest-tests/src/test/resources/features/publicapi/connections.feature
@@ -15,6 +15,7 @@ Feature: Public API - connections point
     When update properties of connection PostgresDB
       | user   | myuser    |
       | schema | sampledb2 |
+    And sleep for jenkins delay or "5" seconds
     Then check that PostgresDB connection contains properties
       | user   | myuser    |
       | schema | sampledb2 |

--- a/ui-tests/src/test/java/io/syndesis/qe/fragments/common/form/Form.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/fragments/common/form/Form.java
@@ -1,5 +1,7 @@
 package io.syndesis.qe.fragments.common.form;
 
+import static io.syndesis.qe.utils.Conditions.STALE_ELEMENT;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 import static com.codeborne.selenide.Condition.exist;
@@ -90,7 +92,7 @@ public class Form {
         TestUtils.waitFor(() -> getRootElement().shouldBe(visible).exists(),
             1, 20, "Form root element not found in 20s");
         for (String tagName : Arrays.asList("input", "select", "textarea", "button", "div", "checkbox")) {
-            for (SelenideElement element : getRootElement().shouldBe(visible).findAll(By.tagName(tagName))) {
+            for (SelenideElement element : getRootElement().shouldBe(visible).findAll(By.tagName(tagName)).exclude(STALE_ELEMENT)) {
                 inputsMap.put(element.getAttribute(fillBy.attribute), tagName);
             }
         }

--- a/ui-tests/src/test/java/io/syndesis/qe/utils/Conditions.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/utils/Conditions.java
@@ -1,6 +1,7 @@
 package io.syndesis.qe.utils;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
 import com.codeborne.selenide.Condition;
@@ -18,6 +19,17 @@ public class Conditions {
         @Override
         public boolean apply(Driver driver, WebElement webElement) {
             return webElement.findElements(Alert.Element.CLOSE_BUTTON).isEmpty();
+        }
+    };
+    public static final Condition STALE_ELEMENT = new Condition("Element is stale") {
+        @Override
+        public boolean apply(Driver driver, WebElement webElement) {
+            try {
+                webElement.isEnabled();
+                return false;
+            } catch (StaleElementReferenceException expected) {
+                return true;
+            }
         }
     };
 }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@oauth-gcalendar`
Test fix for https://github.com/syndesisio/syndesis-qe/pull/1443