### PR TITLE
[FUSEQE-8681] Fix extension delete test

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/fragments/common/form/Form.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/fragments/common/form/Form.java
@@ -92,7 +92,10 @@ public class Form {
         TestUtils.waitFor(() -> getRootElement().shouldBe(visible).exists(),
             1, 20, "Form root element not found in 20s");
         for (String tagName : Arrays.asList("input", "select", "textarea", "button", "div", "checkbox")) {
-            for (SelenideElement element : getRootElement().shouldBe(visible).findAll(By.tagName(tagName)).exclude(STALE_ELEMENT)) {
+            for (SelenideElement element : getRootElement().shouldBe(visible).findAll(By.tagName(tagName))) {
+                if (element.is(STALE_ELEMENT)) {
+                    continue;
+                }
                 inputsMap.put(element.getAttribute(fillBy.attribute), tagName);
             }
         }

--- a/ui-tests/src/test/resources/features/customizations/extension-CRUD.feature
+++ b/ui-tests/src/test/resources/features/customizations/extension-CRUD.feature
@@ -66,5 +66,6 @@ Feature: Customization - Extensions CRUD
     Then check visibility of dialog page "Are you sure you want to delete the "Log Message Body" extension?"
 
     When click on the modal dialog "Delete" button
+    And remove all "success" alerts
   #  And sleep for jenkins delay or "3" seconds
     Then check that technical extension "Log Message Body" is not visible


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@extension-CRUD-delete`