### PR TITLE
[ENTESB-11455] Remove verification for non-existant response body

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/api-provider.feature
+++ b/ui-tests/src/test/resources/features/integrations/api-provider.feature
@@ -547,10 +547,6 @@ Feature: API Provider Integration
     # update existing
     When execute DELETE on API Provider route i-todo-integration-delete endpoint "/api/1"
     Then verify response has status 204
-    And verify response has body
-    """
-
-    """
     And validate that number of all todos with task "task1" is "0"
     And validate that number of all todos with task "task2" is "1"
 


### PR DESCRIPTION
//test: `@ENTESB-11455`
The response body is null, so checking for it to be empty causes errors, the important detail is the response code.
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
