### PR TITLE
[FIX] Fix sveres testsuite

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/steps/CommonSteps.java
@@ -155,7 +155,7 @@ public class CommonSteps {
 
         try {
             OpenShiftWaitUtils.waitFor(() -> WebDriverRunner.getWebDriver().getCurrentUrl().contains("login") ||
-                $(By.className("login")).is(visible), 20 * 1000);
+                $(By.className("pf-c-login")).is(visible), 20 * 1000);
         } catch (InterruptedException | TimeoutException e) {
             fail("Log in page was never loaded");
         }


### PR DESCRIPTION
actually backport to 1.9.x

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
