### PR TITLE
Fix enabling test support on operator DC

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/TestSuiteParent.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestSuiteParent.java
@@ -2,13 +2,16 @@ package io.syndesis.qe;
 
 import io.syndesis.qe.bdd.CommonSteps;
 import io.syndesis.qe.resource.ResourceFactory;
+import io.syndesis.qe.test.InfraFail;
 import io.syndesis.qe.utils.OpenShiftUtils;
 import io.syndesis.qe.utils.TestUtils;
+import io.syndesis.qe.wait.OpenShiftWaitUtils;
 
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.util.Map;
+import java.util.concurrent.TimeoutException;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -28,10 +31,19 @@ public abstract class TestSuiteParent {
 
         if (TestConfiguration.enableTestSupport()) {
             log.info("Enabling test support");
-            OpenShiftUtils.updateEnvVarInDeploymentConfig("syndesis-server", "ENDPOINTS_TEST_SUPPORT_ENABLED", "true");
-            log.info("Waiting for syndesis");
-            TestUtils.sleepIgnoreInterrupt(10 * 1000L);
-            CommonSteps.waitForSyndesis();
+            if (OpenShiftUtils.dcContainsEnv("syndesis-operator", "TEST_SUPPORT") &&
+                OpenShiftUtils.envInDcContainsValue("syndesis-operator", "TEST_SUPPORT", "true")) {
+                log.info("TEST_SUPPORT is already enabled");
+            } else {
+                OpenShiftUtils.updateEnvVarInDeploymentConfig("syndesis-operator", "TEST_SUPPORT", "true");
+                try {
+                    OpenShiftWaitUtils.waitForPodIsReloaded("syndesis-operator");
+                    OpenShiftWaitUtils.waitForPodIsReloaded("syndesis-server");
+                    CommonSteps.waitForSyndesis();
+                } catch (InterruptedException | TimeoutException e) {
+                    InfraFail.fail("Wait for Syndesis failed, check error logs for details.", e);
+                }
+            }
         }
 
         if (!TestConfiguration.namespaceCleanup()) {
@@ -49,9 +61,9 @@ public abstract class TestSuiteParent {
         Map<String, String> labels = TestUtils.map("syndesis-qe/lastUsedBy", System.getProperty("user.name"));
         OpenShiftUtils.getInstance().namespaces().withName(TestConfiguration.openShiftNamespace()).edit()
             .editMetadata()
-                .addToLabels(labels)
+            .addToLabels(labels)
             .endMetadata()
-        .done();
+            .done();
         // @formatter:on
 
         try {

--- a/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/OpenShiftUtils.java
@@ -392,4 +392,17 @@ public final class OpenShiftUtils {
                 && ("ImagePullBackOff".equals(status.getState().getWaiting().getReason()) ||
                 "ErrImagePull".equals(status.getState().getWaiting().getReason())));
     }
+
+    public static boolean dcContainsEnv(String dcName, String envName) {
+        return OpenShiftUtils.getInstance().getDeploymentConfig(dcName)
+            .getSpec().getTemplate().getSpec().getContainers().get(0).getEnv()
+            .stream().anyMatch(envVar -> envVar.getName().equals(envName));
+    }
+
+    public static boolean envInDcContainsValue(String dcName, String envName, String envValue) {
+        EnvVar envVar = OpenShiftUtils.getInstance().getDeploymentConfig(dcName)
+            .getSpec().getTemplate().getSpec().getContainers().get(0).getEnv().stream().filter(env -> env.getName().equals(envName)).findAny()
+            .get();
+        return envValue.equals(envVar.getValue());
+    }
 }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci

Fixed a possibility to enable test support via a test suite. It is needed for test suite containerization.

Backports:
https://github.com/syndesisio/syndesis-qe/pull/1493
https://github.com/syndesisio/syndesis-qe/pull/1494