### PR TITLE
 Add databuckets in datamapper for API Import/Export test and fix Operator Metrics rest test

### DIFF
--- a/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/OperatorMetricsEndpointSteps.java
+++ b/rest-tests/src/test/java/io/syndesis/qe/rest/tests/steps/OperatorMetricsEndpointSteps.java
@@ -23,7 +23,8 @@ public class OperatorMetricsEndpointSteps {
     @Then("verify whether operator metrics endpoint includes version information")
     public void checkVersion() throws IOException {
         try (LocalPortForward ignored = TestUtils.createLocalPortForward(
-            OpenShiftUtils.getPod(p -> p.getMetadata().getName().startsWith("syndesis-operator")), 8383, 8383)) {
+            //skip syndesis-operator-{d}-deploy pods
+            OpenShiftUtils.getPod(p -> p.getMetadata().getName().matches("syndesis-operator-\\d-(?!deploy).*")), 8383, 8383)) {
             assertThat(HttpUtils.doGetRequest("http://localhost:8383/metrics").getBody()).contains("syndesis_version_info{operator_version");
         }
     }

--- a/ui-tests/src/test/resources/features/integrations/integration-import-export-open-api.feature
+++ b/ui-tests/src/test/resources/features/integrations/integration-import-export-open-api.feature
@@ -54,10 +54,10 @@ Feature: API Provider Integration - Import Export
 
     And add integration step on position "1"
     And select "Data Mapper" integration step
-    And create data mapper mappings
-      | body.id        | body.id        |
-      | body.completed | body.completed |
-      | body.task      | body.task      |
+    And create data mapper mappings with data bucket
+      | 2 - Response | body.id        |  | body.id        |
+      | 2 - Response | body.completed |  | body.completed |
+      | 2 - Response | body.task      |  | body.task      |
     And sleep for jenkins delay or "2" seconds
     And check "Done" button is "visible"
     And click on the "Done" button


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@import-export-open-api`
