### PR TITLE
[FUSEQE-9414] improve datamapper instability on Chrome

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -750,7 +750,8 @@ public class Syndesis implements Resource {
         Pod podAfterWait = OpenShiftUtils.getPodByPartialName(partialPodName).get(); //needs to get new instance of the pod
         if (OpenShiftUtils.hasPodIssuesPullingImage(podAfterWait)) {
             log.info(
-                "{} failed to pull image (probably due to permission to the Red Hat registry), linking secret with the SA and restarting the pod",
+                "{} failed to pull image (probably due to permission to the Red Hat registry), the test suite is linking secret with the SA and " +
+                    "the pod is going to be restarted",
                 podAfterWait.getMetadata().getName());
             linkServiceAccountWithSyndesisPullSecret(serviceAccountName);
             OpenShiftUtils.getInstance().deletePod(podAfterWait);


### PR DESCRIPTION
* when the constant/property modalDialog is closed, the tooltip for adding, which was opened before, remains open. It may cause instability on chrome. Added click on root element (the tooltip is disappeared)
* clarified log message for Jaeger SA

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

@mmuzikar  We will see after nightly run whether this change and removing stale elements from `DataMapper#openDataMapperCollectionElement` resolved instability on chrome platform.
```

Element not found {$$(2 elements)[0]}
```
 
