### PR TITLE
[FUSEQE-9414] Fix datamapper instability on Chrome

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -8,13 +8,11 @@ import static org.assertj.core.api.Assertions.fail;
 import static com.codeborne.selenide.Condition.disabled;
 import static com.codeborne.selenide.Condition.visible;
 import static com.codeborne.selenide.Selenide.$;
-import static com.codeborne.selenide.Selenide.$$;
 
 import io.syndesis.qe.pages.ModalDialogPage;
 import io.syndesis.qe.pages.SyndesisPageObject;
 import io.syndesis.qe.utils.Alert;
 import io.syndesis.qe.utils.ByUtils;
-import io.syndesis.qe.utils.Conditions;
 import io.syndesis.qe.utils.TestUtils;
 
 import org.openqa.selenium.By;
@@ -77,12 +75,25 @@ public class DataMapper extends SyndesisPageObject {
         boolean mapperCollectionFound = TestUtils.waitForNoFail(() -> $(Element.COLLECTION_ROOT).is(visible),
             1, 3);
 
+        //during investigating instability on chrome, i noticed that the datamapper is reloaded after 2-3sec, so after that
+        // the all collection are not expanded. I am not able to reproduce it manually, maybe some problem with chrome driver
+        TestUtils.sleepIgnoreInterrupt(4000);
         if (mapperCollectionFound) {
-            for (SelenideElement element : $$(Element.COLLECTION_ROOT).exclude(STALE_ELEMENT)) {
-                if (element.attr("aria-expanded").equals("false")) {
-                    // collection has not been expanded yet
-                    element.click();
-                }
+            ElementsCollection dataMapperCollections = getSourceElementColumn().$$(Element.COLLECTION_ROOT).exclude(STALE_ELEMENT);
+            log.info("DataMapper Source column contains {} collections for expand", dataMapperCollections.size());
+            expandCollection(dataMapperCollections);
+
+            dataMapperCollections = getTargetElementColumn().$$(Element.COLLECTION_ROOT).exclude(STALE_ELEMENT);
+            log.info("DataMapper Target column contains {} collections for expand", dataMapperCollections.size());
+            expandCollection(dataMapperCollections);
+        }
+    }
+
+    private void expandCollection(ElementsCollection collectionsCollection) {
+        for (SelenideElement element : collectionsCollection) {
+            if (element.attr("aria-expanded").equals("false")) {
+                // collection has not been expanded yet
+                element.click();
             }
         }
     }
@@ -95,6 +106,8 @@ public class DataMapper extends SyndesisPageObject {
         modalDialogPage.selectValueByDataTestid(Element.CONSTANT_TYPE, type);
         modalDialogPage.getButton("Confirm").shouldBe(visible).click();
         this.removeAllAlertsFromPage(Alert.WARNING);
+        //when the modalDialog is closed, the tooltip remains open, maybe it causes instability on chrome
+        getSourceElementColumn().find(By.className("pf-c-title")).click();
     }
 
     public void addProperty(String name, String value, String type) {
@@ -106,6 +119,8 @@ public class DataMapper extends SyndesisPageObject {
         modalDialogPage.selectValueByDataTestid(Element.PROPERTY_TYPE, type);
         modalDialogPage.getButton("Confirm").shouldBe(visible).click();
         this.removeAllAlertsFromPage(Alert.WARNING);
+        //when the modalDialog is closed, the tooltip remains open, maybe it causes instability on chrome
+        getSourceElementColumn().find(By.className("pf-c-title")).click();
     }
 
     public void doCreateMapping(String source, String target) {

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -753,7 +753,8 @@ public class Syndesis implements Resource {
         Pod podAfterWait = OpenShiftUtils.getPodByPartialName(partialPodName).get(); //needs to get new instance of the pod
         if (OpenShiftUtils.hasPodIssuesPullingImage(podAfterWait)) {
             log.info(
-                "{} failed to pull image (probably due to permission to the Red Hat registry), linking secret with the SA and restarting the pod",
+                "{} failed to pull image (probably due to permission to the Red Hat registry), the test suite is linking secret with the SA and " +
+                    "the pod is going to be restarted",
                 podAfterWait.getMetadata().getName());
             linkServiceAccountWithSyndesisPullSecret(serviceAccountName);
             OpenShiftUtils.getInstance().deletePod(podAfterWait);


### PR DESCRIPTION
* when the constant/property modalDialog is closed, the tooltip for adding, which was opened before, remains open. It may cause instability on chrome. Added click on root element (the tooltip is disappeared)
* clarified log message for Jaeger SA

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
