### PR TITLE
[hotfix] datamapper

### DIFF
--- a/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
+++ b/ui-tests/src/test/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java
@@ -245,7 +245,8 @@ public class DataMapper extends SyndesisPageObject {
         ElementsCollection rowsWithName = containerElement
             .findAll(Element.MAPPING_FIELD_ITEM_ROW)
             .filter(Condition.attribute("aria-level", String.valueOf(nestedLevel)))
-            .filter(Condition.text(name));
+            // if the row has same name or the name is a part of sentence (must be space before and after, for properties in datamapper `properties = value`)
+            .filter(Condition.matchText("^(.* )?" + name + "( .*)?$"));
         log.debug("SIZE: *{}*, ", rowsWithName.size());
         if (rowsWithName.size() == 0) {
             return null;


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci

DM select the field with contains, it caused the failure that when the user wants to map `text` field and DM contains e.g. following fields
```
text
field2text
text22
```
Also, there cannot be used equal method, because fields in the property data bucket contains also default value in the name e.g.
```
text = default
```