### PR TITLE
Fix webhook in conditional flow and revert RP dummy tests

### DIFF
--- a/ui-tests/src/test/resources/features/integrations/conditional-flow.feature
+++ b/ui-tests/src/test/resources/features/integrations/conditional-flow.feature
@@ -172,37 +172,37 @@ Feature: Conditional flows - content base routing
 
     When select the "integrations-conditional-flows-functional-test" integration
     And invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 0 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     And invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-functional-test | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 2 row output
@@ -257,37 +257,37 @@ Feature: Conditional flows - content base routing
 
     When select the "integrations-conditional-flows-functional-test2" integration
     And invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 0 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 1 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 1 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-functional-test2 | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 2 row output
@@ -443,43 +443,43 @@ Feature: Conditional flows - content base routing
 
     When select the "integrations-conditional-flows-add-delete-step" integration
     And invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 0 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 2 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 0 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 3 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 1 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone2"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone2"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 4 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 2 row output
 
     And invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"John"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"John"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 6 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 2 row output
     And check that query "select * from contact where first_name='Clone was here'" has 2 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Shaco"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Shaco"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 6 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 4 row output
     And check that query "select * from contact where first_name='Clone was here'" has 2 row output
 
     When invoke post request to webhook
-      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone"} | 204 |
+      | integrations-conditional-flows-add-delete-step | test-webhook | {"message":"Clone"} | 200 |
     Then check that query "select * from contact where first_name='Noone was here'" has 7 row output
     And check that query "select * from contact where first_name='Shaco was here'" has 4 row output
     And check that query "select * from contact where first_name='Clone was here'" has 3 row output

--- a/ui-tests/src/test/resources/features/other/support-page.feature
+++ b/ui-tests/src/test/resources/features/other/support-page.feature
@@ -31,17 +31,6 @@ Feature: Support page
     When navigates to the "About" page in help menu
     Then check that build id exists in about page
 
-  @reportPortal
-  Scenario: ReportPortalTest
-    When navigates to the "About1" page in help menu
-
-  @reportPortal
-  Scenario: ReportPortalTest2
-    When navigates to the "About" page in help menu
-
-  @reportPortal
-  Scenario: ReportPortalTest3
-    When navigates to the "About2" page in help menu
 #
 #  2. download all diagnostic info
 #


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci
Fixed the conditional flow test + reverted the dummy tests which were accidentally added by this PR https://github.com/syndesisio/syndesis-qe/pull/1638