### PR TITLE
Disable camel-k tests

### DIFF
--- a/ui-tests/src/test/resources/features/other/camelk.feature
+++ b/ui-tests/src/test/resources/features/other/camelk.feature
@@ -1,4 +1,5 @@
 # @sustainer: mmuzikar@redhat.com
+@disable
 @camel-k
 Feature: Camel-k Runtime
 


### PR DESCRIPTION
//skip-ci 
Camel-k is no longer part of Fuse Online, so the tests fail. 
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
