### PR TITLE
Fixed unstability for operatorhub install when bundle was not pulled

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -821,18 +821,19 @@ public class Syndesis implements Resource {
             } else {
                 Bundle.createSubscription(ocpSvc, "fuse-online", "fuse-online-v7.8.x", "''", "fuse-online-test-catalog");
             }
+            OpenShiftWaitUtils.waitFor(OpenShiftWaitUtils.areExactlyNPodsRunning("name", "syndesis-operator", 1));
         } catch (IOException | TimeoutException | InterruptedException e) {
             e.printStackTrace();
         }
         createPullSecret();
         if (TestConfiguration.enableTestSupport()) {
-            enableTestSupport();
+            TestUtils.withRetry(this::enableTestSupport, 5, 10, "Failed to patch CSV");
         }
         deployCrAndRoutes();
         CommonSteps.waitForSyndesis();
     }
 
-    private void enableTestSupport() {
+    private boolean enableTestSupport() {
         TestUtils.waitFor(() -> "AtLatestKnown".equalsIgnoreCase(getSubscription().getJSONObject("status").getString("state")), 2, 60 * 3,
             "CSV didn't get installed in time");
         JSONObject json = new JSONObject(
@@ -846,8 +847,10 @@ public class Syndesis implements Resource {
         try {
             OpenShiftUtils.getInstance().customResource(getCSVContext())
                 .edit(TestConfiguration.openShiftNamespace(), "fuse-online-operator.v7.8.0", json.toMap());
-        } catch (IOException e) {
+            return true;
+        } catch (Exception e) {
             log.error("Couldn't edit Syndesis CSV", e);
+            return false;
         }
     }
 }


### PR DESCRIPTION
//skip-ci
Added a wait for the fuse-operator to start, this caused fails when the bundle wasn't pulled to the cluster sometimes. And patching the CSV also failed sometimes when operator and the testsuite were changing it at the same time.
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
