### PR TITLE
Add dynamic wait to sns rest test

### DIFF
--- a/rest-tests/src/test/resources/features/integration-sns.feature
+++ b/rest-tests/src/test/resources/features/integration-sns.feature
@@ -28,7 +28,7 @@ Feature: Integration - SNS
     Then wait for integration with name: "AMQ-SNS-<topicName>" to become active
     When publish message with content '{"header":"Hello", "text":"First message!"}' to queue "amq-sns-in"
       And publish message with content '{"header":"Hi", "text":"Second message."}' to queue "amq-sns-in"
-    Then verify that the SQS queue "syndesis-sns-out" has 2 messages after 10 seconds
+    Then wait until integration syndesis-sns-out processed at least 2 messages
       And verify that the SQS queue "syndesis-sns-out" contains notifications related to
         | Hello | First message!  |
         | Hi    | Second message. |

--- a/validation/src/main/java/io/syndesis/qe/validation/CommonSteps.java
+++ b/validation/src/main/java/io/syndesis/qe/validation/CommonSteps.java
@@ -104,6 +104,7 @@ public class CommonSteps {
     @When("deploy public oauth proxy")
     public void deployApiOauthProxy() {
         ResourceFactory.create(PublicOauthProxy.class);
+        TestUtils.sleepForJenkinsDelayIfHigher(5);
     }
 
     @Given("deploy FHIR server")


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci