### PR TITLE
Add credentials for api connector tests + other small fixes

### DIFF
--- a/rest-tests/src/test/resources/features/integration-sns.feature
+++ b/rest-tests/src/test/resources/features/integration-sns.feature
@@ -28,7 +28,7 @@ Feature: Integration - SNS
     Then wait for integration with name: "AMQ-SNS-<topicName>" to become active
     When publish message with content '{"header":"Hello", "text":"First message!"}' to queue "amq-sns-in"
       And publish message with content '{"header":"Hi", "text":"Second message."}' to queue "amq-sns-in"
-    Then wait until integration syndesis-sns-out processed at least 2 messages
+    Then wait until integration AMQ-SNS-<topicName> processed at least 2 messages
       And verify that the SQS queue "syndesis-sns-out" contains notifications related to
         | Hello | First message!  |
         | Hi    | Second message. |

--- a/ui-tests/src/test/resources/features/customizations/connectors/apicurio.feature
+++ b/ui-tests/src/test/resources/features/customizations/connectors/apicurio.feature
@@ -30,6 +30,7 @@ Feature: Customization - API Connector - ApicurIO GUI
 
   @gh-3459
   @ENTESB-11443
+  @ENTESB-16061
   @apicurio-check-warnings-change
   Scenario: Check if warnings change is propagated into connector review page from ApicurIO GUI
     When remove warning via apicurio gui

--- a/ui-tests/src/test/resources/features/integrations/amq-to-rest.feature
+++ b/ui-tests/src/test/resources/features/integrations/amq-to-rest.feature
@@ -34,6 +34,10 @@ Feature: Integration - AMQ to REST
 
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
 
     And click on the "Next" button
     And fill in values by element data-testid

--- a/ui-tests/src/test/resources/features/integrations/api-client-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/api-client-connector.feature
@@ -28,6 +28,10 @@ Feature: Integration - DB to API
 
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
 
     When set up api connector security
       | authType | HTTP Basic Authentication |

--- a/ui-tests/src/test/resources/features/integrations/db-to-db.feature
+++ b/ui-tests/src/test/resources/features/integrations/db-to-db.feature
@@ -334,6 +334,10 @@ Feature: Integration - DB to DB
 
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
 
     When set up api connector security
       | authType | HTTP Basic Authentication |

--- a/ui-tests/src/test/resources/features/integrations/integration-import-export-open-api.feature
+++ b/ui-tests/src/test/resources/features/integrations/integration-import-export-open-api.feature
@@ -28,6 +28,10 @@ Feature: API Provider Integration - Import Export
 
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
 
     And click on the "Next" button
     And fill in values by element data-testid

--- a/ui-tests/src/test/resources/features/integrations/odata-v2.feature
+++ b/ui-tests/src/test/resources/features/integrations/odata-v2.feature
@@ -18,7 +18,7 @@ Feature: OData V2 Connector
 # 1. Parameterized tests for read action.
 #
   @integrations-odata-v2-read
-  Scenario Outline: Read <name> from OData service tests
+  Scenario Outline: Read <name> from OData v2 service tests
 
     # Create new integration
     When click on the "Create Integration" link to create a new integration

--- a/ui-tests/src/test/resources/features/integrations/odata-v4.feature
+++ b/ui-tests/src/test/resources/features/integrations/odata-v4.feature
@@ -19,7 +19,7 @@ Feature: OData V4 Connector
 # 1. Parameterized tests for read action.
 #
   @integrations-odata-v4-read
-  Scenario Outline: Read <name> from OData service tests
+  Scenario Outline: Read <name> from OData v4 service tests
 
     # Create new integration
     When click on the "Create Integration" link to create a new integration
@@ -46,16 +46,16 @@ Feature: OData V4 Connector
 
     # Save integration and publish it
     When click on the "Publish" link
-    And set integration name "OData_Read_2_Log_<name>"
+    And set integration name "OData_Read_4_Log_<name>"
     And publish integration
-    Then Integration "OData_Read_2_Log_<name>" is present in integrations list
-    And wait until integration "OData_Read_2_Log_<name>" gets into "Running" state
+    Then Integration "OData_Read_4_Log_<name>" is present in integrations list
+    And wait until integration "OData_Read_4_Log_<name>" gets into "Running" state
 
     #Validate logs output
-    When wait until integration OData_Read_2_Log_<name> processed at least 1 message
+    When wait until integration OData_Read_4_Log_<name> processed at least 1 message
 
-    Then validate that logs of integration "OData_Read_2_Log_<name>" <does_contain_1> string "<validate_string_1>"
-    And validate that logs of integration "OData_Read_2_Log_<name>" <does_contain_2> string "<validate_string_2>"
+    Then validate that logs of integration "OData_Read_4_Log_<name>" <does_contain_1> string "<validate_string_1>"
+    And validate that logs of integration "OData_Read_4_Log_<name>" <does_contain_2> string "<validate_string_2>"
 
     Examples:
       | name               | key_predicate | query                                                       | does_contain_1 | validate_string_1                                       | does_contain_2  | validate_string_2        |
@@ -106,11 +106,11 @@ Feature: OData V4 Connector
 
     #Then check visibility of page "add to integration"
     When click on the "Publish" link
-    And set integration name "OData_Create"
+    And set integration name "OData_4_Create"
     And publish integration
-    Then Integration "OData_Create" is present in integrations list
-    And wait until integration "OData_Create" gets into "Running" state
-    And wait until integration OData_Create processed at least 1 message
+    Then Integration "OData_4_Create" is present in integrations list
+    And wait until integration "OData_4_Create" gets into "Running" state
+    And wait until integration OData_4_Create processed at least 1 message
 
     Then validate that OData service contains entity with "Name":"Jianathan" property:value pair in "Products" collection
 
@@ -152,18 +152,18 @@ Feature: OData V4 Connector
     And check that OData "1" entity in "Products" collection contains
       |  |
     When click on the "Publish" link
-    And set integration name "OData_Delete"
+    And set integration name "OData_4_Delete"
     And publish integration
-    Then Integration "OData_Delete" is present in integrations list
-    And wait until integration "OData_Delete" gets into "Running" state
-    And wait until integration OData_Delete processed at least 1 message
+    Then Integration "OData_4_Delete" is present in integrations list
+    And wait until integration "OData_4_Delete" gets into "Running" state
+    And wait until integration OData_4_Delete processed at least 1 message
 
     Then check that entity "1" is not present in "Products" collection on OData service
 
   # Those bugs were very similar in reproducing - created one scenario outline for all of them
   @reproducer
   @integrations-odata-v4-read-update
-  Scenario Outline: Read <name> from OData service tests
+  Scenario Outline: Read <name> from OData v4 service tests
 
     # Create new integration
     When click on the "Create Integration" link to create a new integration
@@ -200,13 +200,13 @@ Feature: OData V4 Connector
 
     # Save integration and publish it
     When publish integration
-    And set integration name "<name>"
+    And set integration name "Odata_v4_<name>"
     And publish integration
-    Then Integration "<name>" is present in integrations list
-    And wait until integration "<name>" gets into "Running" state
+    Then Integration "Odata_v4_<name>" is present in integrations list
+    And wait until integration "Odata_v4_<name>" gets into "Running" state
 
     #Validate logs output
-    And wait until integration <name> processed at least 1 message
+    And wait until integration Odata_v4_<name> processed at least 1 message
 
     Then validate that OData service contains entity with "<key>":"<value>" property:value pair in "<resource_collection>" collection
 
@@ -274,11 +274,11 @@ Feature: OData V4 Connector
 
     # Save integration and publish it
     When publish integration
-    And set integration name "Enum"
+    And set integration name "Enum_v4"
     And publish integration
-    Then Integration "Enum" is present in integrations list
-    And wait until integration "Enum" gets into "Running" state
-    And wait until integration Enum processed at least 1 message
+    Then Integration "Enum_v4" is present in integrations list
+    And wait until integration "Enum_v4" gets into "Running" state
+    And wait until integration Enum_v4 processed at least 1 message
 
     #Validate logs output
     Then check that OData "whatever" entity in "Users" collection contains

--- a/ui-tests/src/test/resources/features/integrations/sql-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/sql-connector.feature
@@ -135,16 +135,6 @@ Feature: SQL Connector
       | test6 | id <= :#id AND id > 1 | 3     | 2,3     |
       | test7 | id BETWEEN :#id AND 4 | 2     | 2,3,4   |
       | test8 | id <= :#id OR id = 5  | 3     | 1,2,3,5 |
-    @gh-5084
-    @ENTESB-11487
-    Examples:
-      | name   | predicate        | value | result |
-      | test9  | :#id > id        | 3     | 1,2    |
-      | test10 | (id+1) < :#id    | 4     | 1,2    |
-      | test11 | id in (1, :#id)  | 4     | 1,4    |
-      | test12 | id = floor(:#id) | 4     | 4      |
-
-
 
   @reproducer
   @gh-4466

--- a/ui-tests/src/test/resources/features/integrations/webhook-api-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/webhook-api-connector.feature
@@ -25,6 +25,10 @@ Feature: Integration - Webhook to API connector
 
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
 
     And click on the "Next" button
     And fill in values by element data-testid

--- a/ui-tests/src/test/resources/features/soak-deployments/maxIntegrations.feature
+++ b/ui-tests/src/test/resources/features/soak-deployments/maxIntegrations.feature
@@ -212,6 +212,10 @@ Feature: Test maximum integration
     Then check visibility of page "Review Actions"
     When click on the "Next" link
     Then check visibility of page "Specify Security"
+    #fill in dummy credentials
+    And fill in values by element ID
+      | username | dummy |
+      | password | dummy |
     When click on the "Next" button
     And fill in values by element data-testid
       | name     | Todo connector |


### PR DESCRIPTION
* amq-sns test: Fixed name of the integration
* add dummy credentials to the api connector test  which requires http basic auth
* distinguish odata scenario name (v2 and v4) due to reportportal
* add new issue tag to the apicurito test
* remove SQL failing tests since the enhancement was closed (won't do) (https://issues.redhat.com/browse/FUSEDOC-4434)
//skip-ci
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
