### PR TITLE
Revert apicurito dependency (PR #1729) + remove apicurito sleep step …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,7 @@
 		<ws.rs-api.version>2.1</ws.rs-api.version>
 		<validation-api.version>2.0.1.Final</validation-api.version>
 		<slf4j-api.version>1.7.30</slf4j-api.version>
+		<apicurito.tests.version>0.0.3-SNAPSHOT</apicurito.tests.version>
 		<fhir.version>4.1.0</fhir.version>
 		<cluecumber.version>2.5.0</cluecumber.version>
 		<okhttp.client.version>3.12.6</okhttp.client.version>

--- a/ui-common/pom.xml
+++ b/ui-common/pom.xml
@@ -19,6 +19,14 @@
 		</dependency>
 
 		<dependency>
+			<groupId>apicurio</groupId>
+			<artifactId>apicurito-tests</artifactId>
+			<classifier>tests</classifier>
+			<version>${apicurito.tests.version}</version>
+			<type>test-jar</type>
+		</dependency>
+
+		<dependency>
 			<groupId>com.codeborne</groupId>
 			<artifactId>selenide</artifactId>
 		</dependency>

--- a/ui-tests/src/test/resources/features/integrations/api-provider.feature
+++ b/ui-tests/src/test/resources/features/integrations/api-provider.feature
@@ -219,7 +219,7 @@ Feature: API Provider Integration
 
     And add integration step on position "1"
     And select "Data Mapper" integration step
-    And sleep for 2 seconds
+    And sleep for "2000" ms
     And create data mapper mappings
       | id        | body.id        |
       | completed | body.completed |
@@ -583,7 +583,7 @@ Feature: API Provider Integration
     And sleep for jenkins delay or 3 seconds
     And start integration "TODO Integration import export"
     And navigate to the "Integrations" page
-    And sleep for 20 seconds
+    And sleep for "20000" ms
     Then wait until integration "TODO Integration import export" gets into "Running" state
 
     When execute GET on API Provider route i-todo-integration-import-export endpoint "/api/1"
@@ -880,7 +880,7 @@ Feature: API Provider Integration
     And create data mapper mappings
       | parameters.id | body.id |
     And sleep for jenkins delay or 2 seconds
-    And sleep for 2 seconds
+    And sleep for "2000" ms
     And check "Done" button is "visible"
     And click on the "Done" button
 
@@ -900,7 +900,7 @@ Feature: API Provider Integration
       | id        | body.id        |
       | completed | body.completed |
       | task      | body.task      |
-    And sleep for 2 seconds
+    And sleep for "2000" ms
     And check "Done" button is "visible"
     And click on the "Done" button
 

--- a/ui-tests/src/test/resources/features/integrations/data-mapper.feature
+++ b/ui-tests/src/test/resources/features/integrations/data-mapper.feature
@@ -28,7 +28,7 @@ Feature: Data Mapper
 
     And add integration step on position "0"
     And select "Data Mapper" integration step
-    And sleep for 2 seconds
+    And sleep for "2000" ms
     And create data mapper mappings
       | task | task |
     And click on the "Done" button

--- a/ui-tests/src/test/resources/features/integrations/google-sheets.feature
+++ b/ui-tests/src/test/resources/features/integrations/google-sheets.feature
@@ -68,7 +68,7 @@ Feature: Google Sheets Connector
     And navigate to the "Integrations" page
     And wait until integration "create-sheet" gets into "Running" state
     And wait until integration create-sheet processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that spreadsheet was created
 
   @spreadsheet-append
@@ -115,7 +115,7 @@ Feature: Google Sheets Connector
     And navigate to the "Integrations" page
     And wait until integration "from-db-to-sheets" gets into "Running" state
     And wait until integration from-db-to-sheets processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that test sheet contains values on range "A1:E5"
       | Matej | Foo    | Red Hat | db |
       | Matej | Bar    | Red Hat | db |
@@ -161,11 +161,11 @@ Feature: Google Sheets Connector
     When publish integration
     And set integration name "from-db-to-sheets-update"
     And publish integration
-    And sleep for 10 seconds
+    And sleep for "10000" ms
     And Integration "from-db-to-sheets-update" is present in integrations list
     And wait until integration "from-db-to-sheets-update" gets into "Running" state
     And wait until integration from-db-to-sheets-update processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that test sheet contains values on range "A2:D2"
       | New | Updated | Red Hat | db |
 
@@ -216,7 +216,7 @@ Feature: Google Sheets Connector
     And navigate to the "Integrations" page
     And wait until integration "from-db-to-sheets-update-column" gets into "Running" state
     And wait until integration from-db-to-sheets-update-column processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that test sheet contains values on range "E1:E5"
       | Fuse   |
       | Online |
@@ -292,7 +292,7 @@ Feature: Google Sheets Connector
     And navigate to the "Integrations" page
     And wait until integration "pivot-table" gets into "Running" state
     And wait until integration pivot-table processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that data test sheet contains values on range "'pivot rows'!A1:B90"
       | LAFAYETTE COUNTY | 223   |
       | LAKE COUNTY      | 364   |
@@ -329,7 +329,7 @@ Feature: Google Sheets Connector
     And navigate to the "Integrations" page
     And wait until integration "update-sheet-title" gets into "Running" state
     And wait until integration update-sheet-title processed at least 1 message
-    And sleep for 3 seconds
+    And sleep for "3000" ms
     Then verify that spreadsheet title match "updated-title"
 
   Scenario: get properties of sheet

--- a/ui-tests/src/test/resources/features/integrations/mongodb.feature
+++ b/ui-tests/src/test/resources/features/integrations/mongodb.feature
@@ -59,7 +59,7 @@ Feature: MongoDB
     And publish integration
     And navigate to the "Integrations" page
     And wait until integration "Mongo to DB consume stream" gets into "Running" state
-    And sleep for 10 seconds
+    And sleep for "10000" ms
 
     And insert the following documents into mongodb collection "insert_stream"
       | _id | value |

--- a/ui-tests/src/test/resources/features/integrations/sql-connector.feature
+++ b/ui-tests/src/test/resources/features/integrations/sql-connector.feature
@@ -109,7 +109,7 @@ Feature: SQL Connector
     # add data mapper
     And add integration step on position "0"
     And select "Data Mapper" integration step
-    And sleep for 2 seconds
+    And sleep for "2000" ms
     And create data mapper mappings
       | id | id |
     And click on the "Done" button


### PR DESCRIPTION
…from other tests

<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci
Temporary reverted. 
The api-provider.feature and openapi.feature still use the apicurito steps