### PR TITLE
[FUSEQE-12351] - add test for camel header properties

### DIFF
--- a/ui-common/src/main/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
+++ b/ui-common/src/main/java/io/syndesis/qe/steps/integrations/datamapper/DataMapperSteps.java
@@ -53,6 +53,7 @@ public class DataMapperSteps {
     /**
      * Same table as "create data mapper mappings step but with data bucket names"
      * SourceDataBucket | SourceMapping | TargetDataBucket | TargetMapping
+     *
      * @param table
      */
     @ExcludeFromSelectorReports
@@ -92,8 +93,16 @@ public class DataMapperSteps {
     }
 
     @ExcludeFromSelectorReports
-    @When("^define property \"([^\"]*)\" of type \"([^\"]*)\" in data mapper$")
-    public void definePropertyOfTypeInDataMapper(String name, String type) {
-        mapper.addProperty(name, type);
+    @When("^define property \"([^\"]*)\" of type \"([^\"]*)\"  from scope \"([^\"]*)\" in data mapper$")
+    public void definePropertyOfTypeInDataMapper(String name, String type, String scope) {
+        mapper.addProperty(name, type, scope);
+    }
+
+    @ExcludeFromSelectorReports
+    @When("^create data mapping for duplicate property fields \"([^\"]*)\" to \"([^\"]*)\"$")
+    public void createMappingForProperty(String source, String target) {
+        // automatically open all collections for data mapping
+        mapper.openDataMapperCollectionElement();
+        mapper.doCreateMapping(source, target, true);
     }
 }

--- a/ui-common/src/main/java/io/syndesis/qe/utils/ByUtils.java
+++ b/ui-common/src/main/java/io/syndesis/qe/utils/ByUtils.java
@@ -45,6 +45,10 @@ public class ByUtils {
         return By.cssSelector(String.format("*[class*=\"%s\"]", id));
     }
 
+    public static By containsLabel(String label) {
+        return By.cssSelector(String.format("*[label*=\"%s\"]", label));
+    }
+
     private static class ByPartialText extends By {
 
         private final String partialText;

--- a/ui-common/src/main/java/io/syndesis/qe/utils/Conditions.java
+++ b/ui-common/src/main/java/io/syndesis/qe/utils/Conditions.java
@@ -1,6 +1,7 @@
 package io.syndesis.qe.utils;
 
 import org.openqa.selenium.By;
+import org.openqa.selenium.NoSuchElementException;
 import org.openqa.selenium.StaleElementReferenceException;
 import org.openqa.selenium.WebElement;
 
@@ -29,6 +30,18 @@ public class Conditions {
                 return false;
             } catch (StaleElementReferenceException expected) {
                 return true;
+            }
+        }
+    };
+
+    public static final Condition FIELD_IS_MAPPED = new Condition("Data Mapper field is mapped") {
+        @Override
+        public boolean apply(Driver driver, WebElement webElement) {
+            try {
+                webElement.findElement(ByUtils.containsLabel("This field is connected"));
+                return true;
+            } catch (NoSuchElementException expected) {
+                return false;
             }
         }
     };

--- a/ui-tests/src/test/resources/features/integrations/data-mapper.feature
+++ b/ui-tests/src/test/resources/features/integrations/data-mapper.feature
@@ -123,3 +123,61 @@ Feature: Data Mapper
     And invoke post request to webhook in integration Datamapper-reconfigure with token test-webhook and body {"author":"New Author","title":"Book Title"}
     And wait until integration Datamapper-reconfigure processed at least 1 message
     Then validate that number of all todos with task "New Author" is greater than 0
+
+  @ENTESB-14340
+  @data-mapper-properties
+  Scenario: Mapping Camel message headers
+    Given deploy ActiveMQ broker
+    And created connections
+      | Red Hat AMQ | AMQ | AMQ | AMQ connection |
+    And navigate to the "Home" page
+
+    Given truncate "todo" table
+    When insert into "todo" table
+      | task1 |
+      | task2 |
+      | task3 |
+
+    When click on the "Create Integration" link to create a new integration
+    And check that position of connection to fill is "Start"
+
+    When select the "PostgresDB" connection
+    And select "Periodic SQL invocation" integration action
+    And fill in invoke query input with "SELECT * from todo" value
+    And click on the "Next" button
+
+    When select the "AMQ" connection
+    And select "Publish Messages" integration action
+    And fill in values by element data-testid
+      | destinationname | dmprop |
+      | destinationtype | Queue  |
+    And click on the "Next" button
+    And force fill in values by element data-testid
+      | describe-data-shape-form-kind-input | JSON Instance |
+    And fill text into text-editor
+      | {"firstStep":3,"secondStep":1,"previousStep":1} |
+    And click on the "Next" button
+
+    When add integration step on position "0"
+    And select the "PostgresDB" connection
+    And select "Invoke SQL" integration action
+    And fill in invoke query input with "SELECT * from contact" value
+    And click on the "Next" button
+
+    When add integration step on position "1"
+    And select "Data Mapper" integration step
+    And define property "CamelSqlRowCount" of type "Integer"  from scope "1 - SQL Result" in data mapper
+    And create data mapping for duplicate property fields "CamelSqlRowCount" to "firstStep"
+    And define property "CamelSqlRowCount" of type "Integer"  from scope "2 - SQL Result" in data mapper
+    And create data mapping for duplicate property fields "CamelSqlRowCount" to "secondStep"
+    And define property "CamelSqlRowCount" of type "Integer"  from scope "Current Message Header" in data mapper
+    And create data mapping for duplicate property fields "CamelSqlRowCount" to "previousStep"
+    And click on the "Done" button
+
+    When click on the "Publish" link
+    And set integration name "datamapper-properties"
+    And publish integration
+    And wait until integration "datamapper-properties" gets into "Running" state
+    And wait until integration datamapper-properties processed at least 1 message
+
+    Then verify that JMS message with content '{"firstStep":3,"secondStep":1,"previousStep":1}' was received from "queue" "dmprop"


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci

Since the DM can have multiple fields with the same name (but different scope) in the Properties data bucket, `ignoreFieldWithSameNameAlreadyMapped` was added to the DM because test suite doesn't support ( fails ) when there are more fields with the same name on the same level in the databucket. Now, when `ignoreFieldWithSameNameAlreadyMapped` is set to true, all fields with the same name, which are already used in DM, are excluded from searching so only one field is found to mapping.
(https://github.com/mkralik3/syndesis-qe/blob/8f0a03da646114ac0d7f89fd85bdbc5a99265a75/ui-common/src/main/java/io/syndesis/qe/pages/integrations/editor/add/steps/DataMapper.java#L289)
Also, there is a limitation that the property has to be mapped before the new property with the same name is created at the same level (otherwise more than one element will be found).




