### PR TITLE
Make google sheet tests independent from create-spreadsheet test

### DIFF
--- a/ui-common/src/main/java/io/syndesis/qe/steps/CommonSteps.java
+++ b/ui-common/src/main/java/io/syndesis/qe/steps/CommonSteps.java
@@ -247,12 +247,14 @@ public class CommonSteps {
             $(By.partialLinkText(TestConfiguration.keyCloakIdpName())).click();
             KeyCloakLogin kcLogin = new KeyCloakLogin();
             kcLogin.login(TestConfiguration.syndesisUsername(), TestConfiguration.syndesisPassword());
-        } else if (currentUrl.contains("oauth/authorize")) {
+        } else if (currentUrl.contains("oauth/authorize") || currentUrl.contains("oauth%2Fauthorize")) {
             String linkText = "htpasswd";
             if (currentUrl.contains("osp")) {
                 linkText = "HTPasswd";
             }
-            $(By.partialLinkText(linkText)).click();
+            if (!currentUrl.contains("apps-crc.testing")) { // for CRC 1.27, no IDP chooser
+                $(By.partialLinkText(linkText)).click();
+            }
             MinishiftLogin minishiftLogin = new MinishiftLogin();
             minishiftLogin.login(TestConfiguration.syndesisUsername(), TestConfiguration.syndesisPassword());
         }

--- a/ui-common/src/main/java/io/syndesis/qe/steps/other/GoogleSheetsSteps.java
+++ b/ui-common/src/main/java/io/syndesis/qe/steps/other/GoogleSheetsSteps.java
@@ -17,6 +17,15 @@ public class GoogleSheetsSteps {
     @Autowired
     private GoogleSheetsUtils gcu;
 
+    @When("create or clean test spreadsheet")
+    public void createSpreadSheet() {
+        if (gcu.getTestSheetId() == null || "".equals(gcu.getTestSheetId())) {
+            gcu.createTestSheet();
+        } else {
+            gcu.clearSpreadSheetValues("A1:Z500000");
+        }
+    }
+
     @When("define spreadsheetID as constant in data mapper and map it to {string}")
     public void defineSpreadaheetIDAsPropertyInDataMapper(String mapTo) {
         defineSpreadsheetIdInDatamapper(gcu.getTestSheetId(), mapTo);
@@ -30,11 +39,6 @@ public class GoogleSheetsSteps {
     @Given("^clear range \"([^\"]*)\" in data test spreadsheet$")
     public void clearRangeInDataTestSpreadsheet(String range) {
         gcu.clearSpreadSheetValues(gcu.getTestDataSpreadSheet(), range);
-    }
-
-    @When("^clear test spreadsheet$")
-    public void clearTestSpreadsheet() {
-        gcu.clearSpreadSheetValues("A1:Z500000");
     }
 
     @When("define test spreadsheetID as constant in data mapper and map it to {string}")

--- a/ui-tests/src/test/resources/features/integrations/google-sheets.feature
+++ b/ui-tests/src/test/resources/features/integrations/google-sheets.feature
@@ -20,15 +20,11 @@ Feature: Google Sheets Connector
       | Google Sheets | google-sheets |
     And created connections
       | Red Hat AMQ | AMQ | AMQ | AMQ connection |
+    And create or clean test spreadsheet
     And navigate to the "Home" page
 
 
   @create-spreadsheet
-  @big-spreadsheet-copy
-  @big-spreadsheet-db
-  @spreadsheet-append
-  @from-db-rows
-  @from-db-columns
   Scenario: create spreadsheet
     When click on the "Create Integration" link to create a new integration.
     And select the "Timer" connection
@@ -53,7 +49,7 @@ Feature: Google Sheets Connector
     And select the "google-sheets" connection
     And select "Create spreadsheet" integration action
     And fill in values by element data-testid
-      | title | brand-new-spreadsheet |
+      | title | brand-new-spreadsheet-syndesis-tests |
     Then click on the "Next" button
 
     When add integration step on position "1"
@@ -73,8 +69,7 @@ Feature: Google Sheets Connector
 
   @spreadsheet-append
   Scenario: Append messages from DB
-    When clear test spreadsheet
-    And insert into "contact" table
+    When insert into "contact" table
       | Matej | Foo    | Red Hat | db |
       | Matej | Bar    | Red Hat | db |
       | Fuse  | Online | Red Hat | db |
@@ -140,7 +135,6 @@ Feature: Google Sheets Connector
     And fill in values by element data-testid
       | range          | A2:E3                                        |
       | majordimension | Rows                                         |
-      | spreadsheetid  | 1RdaQ1sb90ugxAh1Z6oZD87XhgmmhKs6tDturft_wsAk |
     And click on the "Next" button
     And fill in values by element data-testid
       | columnnames | A,B,C,D,E |
@@ -307,7 +301,7 @@ Feature: Google Sheets Connector
       |               | ALACHUA COUNTY | BAKER COUNTY | BAY COUNTY  |
       | SUM of 498960 | 424134760.5    | 2854645.2    | 640241168.4 |
 
-
+  @update-sheet-title
   Scenario: Update title
     When click on the "Create Integration" link to create a new integration.
     And select the "Timer" connection
@@ -320,7 +314,7 @@ Feature: Google Sheets Connector
     And select "Update spreadsheet properties" integration action
     And fill spreadsheet ID
     And fill in values by element data-testid
-      | title | updated-title |
+      | title | updated-title-syndesis-tests |
     Then click on the "Done" button
 
     When publish integration
@@ -330,8 +324,9 @@ Feature: Google Sheets Connector
     And wait until integration "update-sheet-title" gets into "Running" state
     And wait until integration update-sheet-title processed at least 1 message
     And sleep for "3000" ms
-    Then verify that spreadsheet title match "updated-title"
+    Then verify that spreadsheet title match "updated-title-syndesis-tests"
 
+  @get-sheet-property
   Scenario: get properties of sheet
     When click on the "Create Integration" link to create a new integration.
     And select the "google-sheets" connection
@@ -438,8 +433,7 @@ Feature: Google Sheets Connector
 
   @big-spreadsheet-copy
   Scenario: Copy big spreadsheet using split/aggregate
-    When clear test spreadsheet
-    And click on the "Create Integration" link to create a new integration.
+    When click on the "Create Integration" link to create a new integration.
     And select the "google-sheets" connection
     And select "Get sheet values" integration action
     And fill in data-testid field "spreadsheetid" from property "testDataSheetId" of credentials "QE Google Sheets"

--- a/utilities/src/main/java/io/syndesis/qe/utils/GoogleSheetsUtils.java
+++ b/utilities/src/main/java/io/syndesis/qe/utils/GoogleSheetsUtils.java
@@ -1,6 +1,7 @@
 package io.syndesis.qe.utils;
 
 import io.syndesis.qe.account.AccountsDirectory;
+import io.syndesis.qe.test.InfraFail;
 import io.syndesis.qe.utils.google.GoogleAccounts;
 
 import org.assertj.core.api.Assertions;
@@ -14,6 +15,7 @@ import com.google.api.services.sheets.v4.model.DeleteSheetRequest;
 import com.google.api.services.sheets.v4.model.Request;
 import com.google.api.services.sheets.v4.model.Sheet;
 import com.google.api.services.sheets.v4.model.Spreadsheet;
+import com.google.api.services.sheets.v4.model.SpreadsheetProperties;
 import com.google.api.services.sheets.v4.model.ValueRange;
 
 import java.io.IOException;
@@ -75,10 +77,6 @@ public class GoogleSheetsUtils {
             return false;
         }
         return true;
-    }
-
-    public boolean spreadSheetExists() {
-        return spreadSheetExists(testSheetId);
     }
 
     public List<String> getSpreadSheetValues(String id, String range) {
@@ -155,5 +153,17 @@ public class GoogleSheetsUtils {
 
     public Spreadsheet getSpreadSheet() {
         return getSpreadSheet(testSheetId);
+    }
+
+    public void createTestSheet() {
+        Spreadsheet spreadsheet = new Spreadsheet()
+            .setProperties(new SpreadsheetProperties()
+                .setTitle("syndesis-sheet-" + System.currentTimeMillis())
+            );
+        try {
+            setTestSheetId(getSheets().spreadsheets().create(spreadsheet).setFields("spreadsheetId").execute().getSpreadsheetId());
+        } catch (IOException e) {
+            InfraFail.fail("IOException during creating a spreadsheet" + e);
+        }
     }
 }

--- a/validation/src/main/java/io/syndesis/qe/validation/GoogleSheetsValidationSteps.java
+++ b/validation/src/main/java/io/syndesis/qe/validation/GoogleSheetsValidationSteps.java
@@ -25,11 +25,9 @@ public class GoogleSheetsValidationSteps {
 
     @Then("verify that spreadsheet was created")
     public void verifyThatSpreadsheetWasCreated() {
-        if (sheetsUtils.getTestSheetId() == null || "".equals(sheetsUtils.getTestSheetId())) {
-            sheetsUtils.setTestSheetId(JMSUtils.getMessageText(JMSUtils.Destination.QUEUE, "sheets").split(":")[1].split("\"")[1]);
-            log.info("Spreadsheet ID " + sheetsUtils.getTestSheetId());
-        }
-        Assertions.assertThat(sheetsUtils.spreadSheetExists());
+        String sheetID = JMSUtils.getMessageText(JMSUtils.Destination.QUEUE, "sheets").split(":")[1].split("\"")[1];
+        log.info("Spreadsheet ID " + sheetID);
+        assertThat(sheetsUtils.spreadSheetExists(sheetID)).isTrue();
     }
 
     @Then("verify that test sheet contains values on range {string}")


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//test: `@from-db-rows`

Majority of the spreadsheets tests were depends on create-spreadsheet test. If that test failed, the others failed too ( because the sheet was not created ). 
Now, the sheet is created by the test suite (only one for all tests scenarios in one test run).
