### PR TITLE
Workaround for Jaeger installed by OLM

### DIFF
--- a/utilities/src/main/java/io/syndesis/qe/common/CommonSteps.java
+++ b/utilities/src/main/java/io/syndesis/qe/common/CommonSteps.java
@@ -43,6 +43,10 @@ public class CommonSteps {
         try {
             OpenShiftUtils.getInstance().clean();
             //OpenShiftUtils.getInstance().waiters().isProjectClean().waitFor(); //workaround for 4.7 is need. see description of the next function
+            // workaround for Jaeger installed by OLM
+            OpenShiftUtils.binary().execute("delete", "subscriptions", "jaeger-product");
+            OpenShiftUtils.binary().execute("delete", "csv", "jaeger-operator.v1.20.3");
+
             isProjectClean().waitFor();
         } catch (WaiterException e) {
             log.warn("Project was not clean after 20s, retrying once again");


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->

On the latest OCP 4.7 instances, we are facing an problem with cleaning project method. When the method OpenShiftUtils.getInstance().clean()`` is called, all resources are deleted but after some time, the OperatorHub create jaeger subscriptions again however the installation stuck in missing deployment. When the Syndesis is being installed right after that (e.g. in the operator tests), it doesn't install Jaeger again (because the Jaeger operator is being installed (actually it is stuck :D )). 

Maybe it has been already somehow fixed in XTF method, but we cannot update XTF until the kubernetes client will be updated in Syndesis ( I need to create a feature request for that)

So, here is this ugly fix
