### PR TITLE
Fix for two same desc constant in max integration

### DIFF
--- a/ui-tests/src/test/resources/features/soak-deployments/maxIntegrations.feature
+++ b/ui-tests/src/test/resources/features/soak-deployments/maxIntegrations.feature
@@ -663,13 +663,13 @@ Feature: Test maximum integration
     And add integration step on position "0"
     And select "Data Mapper" integration step
 
-    And define constant "desc" with value "MaxIntegrationsDescription" of type "String" in data mapper
+    And define constant "maxDesc" with value "MaxIntegrationsDescription" of type "String" in data mapper
     And define constant "imp" with value "1" of type "Integer" in data mapper
     And define constant "urgency" with value "2" of type "String" in data mapper
     And define constant "desc" with value "description" of type "String" in data mapper
     And define constant "input" with value "ui" of type "String" in data mapper
     And create data mapper mappings
-      | desc    | u_description       |
+      | maxDesc | u_description       |
       | imp     | u_impact            |
       | urgency | u_urgency           |
       | desc    | u_short_description |


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci