### PR TITLE
Workaround for using local geckodriver in webdrivermanager

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -117,4 +117,9 @@ WORKDIR /home/seluser/syndesis-qe
 
 COPY default-cr.yml /home/seluser/fuse-online-install/
 
+RUN mkdir -p /home/seluser/.cache/selenium/geckodriver/linux64/0.26.0/ \
+    && ln -s /opt/geckodriver-0.26.0 /home/seluser/.cache/selenium/geckodriver/linux64/0.26.0/geckodriver
+
+COPY resolution.properties /home/seluser/.cache/selenium
+
 ENTRYPOINT ["/home/seluser/entrypoint.sh"]

--- a/docker/resolution.properties
+++ b/docker/resolution.properties
@@ -1,0 +1,6 @@
+#WebDriverManager Resolution Cache
+#Tue Mar 08 10:57:57 UTC 2022
+firefox=78
+firefox-ttl=11\:57\:57 08/03/2022 UTC
+firefox78=0.26.0
+firefox78-ttl=10\:57\:57 09/03/2022 UTC


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci