### PR TITLE
Revert workaround 4.11 for 7.11.0

### DIFF
--- a/operator-tests/src/test/java/io/syndesis/qe/OperatorValidationSteps.java
+++ b/operator-tests/src/test/java/io/syndesis/qe/OperatorValidationSteps.java
@@ -126,12 +126,16 @@ public class OperatorValidationSteps {
         try {
             if (file == null) {
                 syndesis.deploySyndesisViaOperator();
-                //don't do workarounds for external Jaeger
             } else {
                 String content = getCrFromFileAsString(file);
                 syndesis.getSyndesisCrClient().create(TestConfiguration.openShiftNamespace(), content);
-                //don't do workarounds for external Jaeger
+                if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0")) {
+                    //workaround is not in version < 7.11.1
+                    syndesis.workaround411();
+                    syndesis.workaround411();
+                }
             }
+            //don't do workarounds for external Jaeger
             if (syndesis.isAddonEnabled(Addon.JAEGER) && !syndesis.containsAddonProperty(Addon.JAEGER, "collectorUri")) {
                 syndesis.jaegerWorkarounds();
             }

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -580,6 +580,11 @@ public class Syndesis implements Resource {
                 crJson.getJSONObject("spec").put("demoData", true);
             }
             createCr(crJson.toMap());
+            if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0")) {
+                //workaround is not in version < 7.11.1
+                workaround411();
+                workaround411();
+            }
         } catch (IOException ex) {
             throw new IllegalArgumentException("Unable to load operator syndesis template", ex);
         }


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
//skip-ci