### PR TITLE
Tweaks in docker image and bump CSV version

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -116,6 +116,6 @@ ENV MODE 'full'
 ENV RETRIES '3'
 ENV VNC 'false'
 ENV CATALOG_SOURCE 'redhat-operators'
-ENV CSV_VERSION 'fuse-online.v7.11.0-0.1665054365.p'
+ENV CSV_CHANNEL 'latest'
 
 ENTRYPOINT ["/home/seluser/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -88,7 +88,7 @@ RUN mvn -P ui clean install -DskipTests
 COPY credentials_minimal.json /syndesis-qe/credentials.json
 
 #================================================================================================================================
-FROM docker.io/selenium/standalone-chrome:103.0 as runningEnv
+FROM docker.io/selenium/standalone-chrome:106.0 as runningEnv
 
 WORKDIR /home/seluser
 COPY --from=buildSyndesisQE /root/.m2/repository/ /home/seluser/.m2/repository/
@@ -116,6 +116,6 @@ ENV MODE 'full'
 ENV RETRIES '3'
 ENV VNC 'false'
 ENV CATALOG_SOURCE 'redhat-operators'
-ENV CSV_VERSION 'fuse-online.v7.11.0-0.1662457147.p'
+ENV CSV_VERSION 'fuse-online.v7.11.0-0.1665054365.p'
 
 ENTRYPOINT ["/home/seluser/entrypoint.sh"]

--- a/operator-tests/src/test/java/io/syndesis/qe/OperatorValidationSteps.java
+++ b/operator-tests/src/test/java/io/syndesis/qe/OperatorValidationSteps.java
@@ -129,7 +129,8 @@ public class OperatorValidationSteps {
             } else {
                 String content = getCrFromFileAsString(file);
                 syndesis.getSyndesisCrClient().create(TestConfiguration.openShiftNamespace(), content);
-                if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0")) {
+                if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0") ||
+                    TestConfiguration.isOperatorHubInstall() && TestConfiguration.getOperatorHubCSVName().contains("fuse-online.v7.11.0")) {
                     //workaround is not in version < 7.11.1
                     syndesis.workaround411();
                     syndesis.workaround411();

--- a/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
+++ b/utilities/src/main/java/io/syndesis/qe/TestConfiguration.java
@@ -394,7 +394,7 @@ public class TestConfiguration {
     }
 
     public static String getOperatorHubCSVName() {
-        return get().readValue(OPERATORHUB_CSV_NAME, "fuse-online.v7.11.0-0.1662457147.p");
+        return get().readValue(OPERATORHUB_CSV_NAME, "fuse-online.v7.11.0-0.1665054365.p");
     }
 
     public static String keycloakNamespace() {

--- a/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
+++ b/utilities/src/main/java/io/syndesis/qe/resource/impl/Syndesis.java
@@ -580,7 +580,8 @@ public class Syndesis implements Resource {
                 crJson.getJSONObject("spec").put("demoData", true);
             }
             createCr(crJson.toMap());
-            if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0")) {
+            if (TestUtils.isProdBuild() && TestConfiguration.syndesisVersion().contains("1.14.0.fuse-7_11_0") ||
+                TestConfiguration.isOperatorHubInstall() && TestConfiguration.getOperatorHubCSVName().contains("fuse-online.v7.11.0")) {
                 //workaround is not in version < 7.11.1
                 workaround411();
                 workaround411();


### PR DESCRIPTION
<!---
PLEASE READ:

You can skip the tests execution using "//skip-ci" anywhere in the pull request description.
To run a particular tag, use following syntax: //test: `@mytag`. In this scenario it will result in running "(@mytag) or @smoke", otherwise, by default, only @smoke tag is triggered.

Unless you want to skip tests (//skip-ci):
1) do not directly request review from anyone
2) use 'Draft' PR until the tests pass and you are satisfied with all the content - then mark the PR as "Ready for review"
-->
* bump csv version in default values
* add workaround for 4.11 in operatorhub installation (due to LPINTEROP since it uses the latest GA 7.11.0)
* update the docker script to get CSV_VERSION dynamically from the cluster when is not set. So the test image doesn't need to be rebuilt after every metadata bundle rebuild

//skip-ci